### PR TITLE
Prevent possible filesystem case-sensitivity issues when requiring bootstrap/Start.php

### DIFF
--- a/themosis.php
+++ b/themosis.php
@@ -192,7 +192,7 @@ if (!class_exists('THFWK_Themosis'))
             // Bootstrap the framework
             if (isset($GLOBALS['THFWK_Themosis']))
             {
-                require_once themosis_path('plugin').'bootstrap'.DS.'start.php';
+                require_once themosis_path('plugin').'bootstrap'.DS.'Start.php';
             }
         }
 


### PR DESCRIPTION
Encountered this issue deploying to a box running CentOS 6.5.
