### PR TITLE
Add ability to set the class of a field

### DIFF
--- a/src/Themosis/Field/Fields/PasswordField.php
+++ b/src/Themosis/Field/Fields/PasswordField.php
@@ -14,6 +14,7 @@ class PasswordField extends FieldBuilder{
     {
         $this->properties = $properties;
         $this->setId();
+        $this->setClass();
         $this->setTitle();
         $this->fieldType();
     }
@@ -37,6 +38,16 @@ class PasswordField extends FieldBuilder{
     private function setId()
     {
         $this['id'] = isset($this['id']) ? $this['id'] : $this['name'].'-id';
+    }
+
+    /**
+     * Set a default class attribute if not defined.
+     *
+     * @return void
+     */
+    private function setClass()
+    {
+        $this['class'] = isset($this['class']) ? $this['class'] : 'large-text';
     }
 
     /**

--- a/src/Themosis/Field/Fields/TextField.php
+++ b/src/Themosis/Field/Fields/TextField.php
@@ -14,6 +14,7 @@ class TextField extends FieldBuilder{
     {
         $this->properties = $properties;
         $this->setId();
+        $this->setClass();
         $this->setTitle();
         $this->fieldType();
     }
@@ -37,6 +38,16 @@ class TextField extends FieldBuilder{
     private function setId()
     {
         $this['id'] = isset($this['id']) ? $this['id'] : $this['name'].'-id';
+    }
+
+    /**
+     * Set a default class attribute if not defined.
+     *
+     * @return void
+     */
+    private function setClass()
+    {
+        $this['class'] = isset($this['class']) ? $this['class'] : 'large-text';
     }
 
     /**

--- a/src/Themosis/Field/Fields/TextareaField.php
+++ b/src/Themosis/Field/Fields/TextareaField.php
@@ -14,6 +14,7 @@ class TextareaField extends FieldBuilder {
     {
         $this->properties = $properties;
         $this->setId();
+        $this->setClass();
         $this->setTitle();
         $this->fieldType();
     }
@@ -26,6 +27,16 @@ class TextareaField extends FieldBuilder {
     private function setId()
     {
         $this['id'] = isset($this['id']) ? $this['id'] : $this['name'].'-id';
+    }
+
+    /**
+     * Set a default class attribute if not defined.
+     *
+     * @return void
+     */
+    private function setClass()
+    {
+        $this['class'] = isset($this['class']) ? $this['class'] : 'large-text';
     }
 
     /**

--- a/src/Themosis/Field/Fields/Views/metabox/_themosisPasswordField.scout.php
+++ b/src/Themosis/Field/Fields/Views/metabox/_themosisPasswordField.scout.php
@@ -1,4 +1,4 @@
-{{ Themosis\Facades\Form::input('password', $field['name'], $field['value'], array('id' => $field['id'], 'class' => 'large-text', 'data-field' => 'password')) }}
+{{ Themosis\Facades\Form::input('password', $field['name'], $field['value'], array('id' => $field['id'], 'class' => $field['class'], 'data-field' => 'password')) }}
 
 @if(isset($field['info']))
     <div class="themosis-field-info">

--- a/src/Themosis/Field/Fields/Views/metabox/_themosisTextField.scout.php
+++ b/src/Themosis/Field/Fields/Views/metabox/_themosisTextField.scout.php
@@ -1,4 +1,4 @@
-{{ Themosis\Facades\Form::text($field['name'], $field['value'], array('id' => $field['id'], 'class' => 'large-text', 'data-field' => 'text')) }}
+{{ Themosis\Facades\Form::text($field['name'], $field['value'], array('id' => $field['id'], 'class' => $field['class'], 'data-field' => 'text')) }}
 
 @if(isset($field['info']))
     <div class="themosis-field-info">

--- a/src/Themosis/Field/Fields/Views/metabox/_themosisTextareaField.scout.php
+++ b/src/Themosis/Field/Fields/Views/metabox/_themosisTextareaField.scout.php
@@ -1,4 +1,4 @@
-{{ Themosis\Facades\Form::textarea($field['name'], $field['value'], array('class' => 'large-text', 'data-field' => 'textarea', 'id' => $field['id'], 'rows' => '5')) }}
+{{ Themosis\Facades\Form::textarea($field['name'], $field['value'], array('class' => $field['class'], 'data-field' => 'textarea', 'id' => $field['id'], 'rows' => '5')) }}
 
 @if(isset($field['info']))
     <div class="themosis-field-info">


### PR DESCRIPTION
The fieldtypes `text`, `password` and `textarea` always get a class of `large-text`, but there are multiple occasions where one might not need such a big input field.
So this pull requests adds the ability to set the class on a field, if no class is set, it will default to `large-text` as usual.

So now you're setting pages can look like this:
![screen1](https://cloud.githubusercontent.com/assets/1297781/5010396/9f8007ca-6a72-11e4-956a-deb34123571a.jpg)

Compared to how they look now:
![screen2](https://cloud.githubusercontent.com/assets/1297781/5010398/abe08648-6a72-11e4-8257-441b58cb4103.jpg)
