### PR TITLE
Include call to wordpress shortcodes prior to returning rendered view.

### DIFF
--- a/src/Themosis/View/View.php
+++ b/src/Themosis/View/View.php
@@ -68,6 +68,8 @@ class View implements ArrayAccess, IRenderable {
     {
         $content = $this->renderContent();
 
+        $content = do_shortcode($content); // wordpress global function
+
         // Flush all sections when the view is rendered.
         $this->factory->flushSectionsIfDoneRendering();
 


### PR DESCRIPTION
This helps to expose shortcodes to end-users who want to use tags in their posts (that's my use case).