### PR TITLE
setting values to forms and explicit checkbox labels

### DIFF
--- a/src/Themosis/Html/FormBuilder.php
+++ b/src/Themosis/Html/FormBuilder.php
@@ -30,6 +30,7 @@ class FormBuilder {
     {
         $this->html = $html;
         $this->request = $request;
+        $this->values = null;
     }
 
     /**
@@ -81,6 +82,18 @@ class FormBuilder {
         }
 
         return '<form'.$this->html->attributes($attributes).'>'.$append;
+    }
+    
+    /**
+     * Set values for a form
+     *
+     * @param array $values name => value pairs of preset fields.
+     * @return FormBuilder this
+     */
+    public function setValues(array $values)
+    {
+        $this->values = $values;
+        return $this;
     }
 
     /**
@@ -177,6 +190,12 @@ class FormBuilder {
      */
     public function input($type, $name, $value = null, array $attributes = array())
     {
+        // check if value is set
+        if($this->values && isset($this->values[$name])) 
+        { 
+            $value = $this->values[$name];
+        }
+        
         $merge = compact('type', 'name', 'value');
 
         $attributes = array_merge($attributes, $merge);

--- a/src/Themosis/Html/FormBuilder.php
+++ b/src/Themosis/Html/FormBuilder.php
@@ -316,6 +316,10 @@ class FormBuilder {
         $i = 0;
         foreach($choices as $choice)
         {
+            if($this->values && isset($this->values[$name])) 
+            { 
+                $value = $this->values[$name];
+            }   
             // Check the value.
             // If checked, add the attribute.
             if (in_array($choice, $value))
@@ -352,8 +356,13 @@ class FormBuilder {
     public function textarea($name, $value = null, array $attributes = array())
     {
         $merge = compact('name');
-
+        
         $attributes = array_merge($attributes, $merge);
+        
+        if($this->values && isset($this->values[$name])) 
+        { 
+            $value = $this->values[$name];
+        }
 
         return '<textarea name="'.$name.'" '.$this->html->attributes($attributes).'>'.$value.'</textarea>';
     }
@@ -382,6 +391,12 @@ class FormBuilder {
         else
         {
             unset($attributes['multiple']);
+        }
+        
+        // check if value is set
+        if($this->values && isset($this->values[$name])) 
+        { 
+            $value = $this->values[$name];
         }
 
         // Build the options of the select tag.

--- a/src/Themosis/Html/FormBuilder.php
+++ b/src/Themosis/Html/FormBuilder.php
@@ -304,7 +304,16 @@ class FormBuilder {
     private function makeGroupCheckableField($type, $name, array $choices, array $value, array $attributes)
     {
         $field = '';
+        $labels = null;
 
+        // Prepare array of labels
+        if(isset($attributes['label']))
+        {
+            $labels = (array) $attributes['label'];
+            unset($attributes['label']);
+        }
+        
+        $i = 0;
         foreach($choices as $choice)
         {
             // Check the value.
@@ -314,11 +323,19 @@ class FormBuilder {
                 $attributes['checked'] = 'checked';
             }
 
+            // Check for explicit label, or use $choice name as label
+            if (!$labels || !isset($labels[$i]))
+            {   
+                $label = ucfirst($choice);
+            } else {
+                $label = $labels[$i];
+            }
             // Build html output
-            $field.= '<label>'.$this->input($type, $name.'[]', $choice, $attributes).ucfirst($choice).'</label>';
+            $field.= '<label>'.$this->input($type, $name.'[]', $choice, $attributes).$label.'</label>';
 
             // Reset 'checked' attributes.
             unset($attributes['checked']);
+            $i++;
         }
 
         return $field;

--- a/src/Themosis/Page/PageBuilder.php
+++ b/src/Themosis/Page/PageBuilder.php
@@ -81,11 +81,11 @@ class PageBuilder extends Wrapper {
      * @param string $slug The page slug name.
      * @param string $title The page display title.
      * @param string $parent The parent's page slug if a subpage.
-     * @param IRenderable $view The page main view file.
+     * @param IRenderable|string $view The page main view object or string in the form of controller|action.
      * @throws PageException
      * @return \Themosis\Page\PageBuilder
      */
-    public function make($slug, $title, $parent = null, IRenderable $view = null)
+    public function make($slug, $title, $parent = null, $view = null)
     {
         $params = compact('slug', 'title');
 
@@ -161,10 +161,19 @@ class PageBuilder extends Wrapper {
      */
     public function displayPage()
     {
-        // Share the page instance to the view.
-        $this->with('__page', $this);
+        if(is_string($this->view))
+        {   $parts = explode('@',$this->view);
+            $controller = new $parts[0];
+            $controller->__page = $this;
+            $view = $controller->$parts[1]();
+            echo $view->render();
+        }
+        else
+        {   // Share the page instance to the view.
+            $this->with('__page', $this);
 
-        echo($this->view->render());
+            echo($this->view->render());
+        }
     }
 
     /**


### PR DESCRIPTION
Hello, I added a simple functionality for the FormBuilder class

1) You can set all the values of the fields at once - which comes in handy when validating a form (to remember users input) and also when populating the form from an Entity

2) I added the possibility of explicitly adding labels to checkboxes. Sometimes you want to show something to the user (i.e. a link to a file, or a fancy description) and use something else as the value in your application.

Best Regards
Jan