### PR TITLE
allow setting of attributes (i.e. disabled, readonly etc.) to input fields

### DIFF
--- a/src/Themosis/Field/Fields/FieldBuilder.php
+++ b/src/Themosis/Field/Fields/FieldBuilder.php
@@ -30,6 +30,7 @@ abstract class FieldBuilder extends DataContainer{
         $this->setId();
         $this->setClass();
         $this->setTitle();
+        $this->setAttributes();
     }
 
     /**
@@ -71,6 +72,16 @@ abstract class FieldBuilder extends DataContainer{
     protected function setTitle()
     {
         $this['title'] = isset($this['title']) ? ucfirst($this['title']) : ucfirst($this['name']);
+    }
+
+    /**
+     * Set default html attributes if not defined.
+     *
+     * @return void
+     */
+    protected function setAttributes()
+    {
+        $this['attributes'] = isset($this['attributes']) ? $this['attributes'] : array();
     }
 
     /**

--- a/src/Themosis/Field/Fields/Views/metabox/_themosisCheckboxField.scout.php
+++ b/src/Themosis/Field/Fields/Views/metabox/_themosisCheckboxField.scout.php
@@ -1,4 +1,4 @@
-{{ Themosis\Facades\Form::checkbox($field['name'], $field['options'], $field['value'], array('id' => $field['id'], 'data-field' => 'checkbox', 'class' => $field['class'])) }}
+{{ Themosis\Facades\Form::checkbox($field['name'], $field['options'], $field['value'], array_merge(array('id' => $field['id'], 'data-field' => 'checkbox', 'class' => $field['class']),$field['attributes'])) }}
 
 @if(isset($field['info']))
     <div class="themosis-field-info">

--- a/src/Themosis/Field/Fields/Views/metabox/_themosisCheckboxesField.scout.php
+++ b/src/Themosis/Field/Fields/Views/metabox/_themosisCheckboxesField.scout.php
@@ -1,4 +1,4 @@
-{{ Themosis\Facades\Form::checkboxes($field['name'], $field['options'], $field['value'], array('data-field' => 'checkbox', 'id' => $field['name'].'-id', 'class' => $field['class'])) }}
+{{ Themosis\Facades\Form::checkboxes($field['name'], $field['options'], $field['value'], array_merge(array('data-field' => 'checkbox', 'id' => $field['name'].'-id', 'class' => $field['class']),$field['attributes'])) }}
 
 @if(isset($field['info']))
     <div class="themosis-field-info">

--- a/src/Themosis/Field/Fields/Views/metabox/_themosisDateField.scout.php
+++ b/src/Themosis/Field/Fields/Views/metabox/_themosisDateField.scout.php
@@ -1,4 +1,4 @@
-{{ Themosis\Facades\Form::date($field['name'], $field['value'], array('id' => $field['id'], 'class' => $field['class'], 'data-field' => 'date')) }}
+{{ Themosis\Facades\Form::date($field['name'], $field['value'], array_merge(array('id' => $field['id'], 'class' => $field['class'], 'data-field' => 'date'), $field['attributes'])) }}
 
 @if(isset($field['info']))
     <div class="themosis-field-info">

--- a/src/Themosis/Field/Fields/Views/metabox/_themosisNumberField.scout.php
+++ b/src/Themosis/Field/Fields/Views/metabox/_themosisNumberField.scout.php
@@ -1,4 +1,4 @@
-{{ Themosis\Facades\Form::number($field['name'], $field['value'], array('id' => $field['id'], 'class' => $field['class'], 'data-field' => 'number')) }}
+{{ Themosis\Facades\Form::number($field['name'], $field['value'], array_merge(array('id' => $field['id'], 'class' => $field['class'], 'data-field' => 'number'), $field['attributes'])) }}
 
 @if(isset($field['info']))
     <div class="themosis-field-info">

--- a/src/Themosis/Field/Fields/Views/metabox/_themosisPasswordField.scout.php
+++ b/src/Themosis/Field/Fields/Views/metabox/_themosisPasswordField.scout.php
@@ -1,4 +1,4 @@
-{{ Themosis\Facades\Form::password($field['name'], $field['value'], array('id' => $field['id'], 'class' => $field['class'], 'data-field' => 'password')) }}
+{{ Themosis\Facades\Form::password($field['name'], $field['value'], array_merge(array('id' => $field['id'], 'class' => $field['class'], 'data-field' => 'password'), $field['attributes'])) }}
 
 @if(isset($field['info']))
     <div class="themosis-field-info">

--- a/src/Themosis/Field/Fields/Views/metabox/_themosisRadioField.scout.php
+++ b/src/Themosis/Field/Fields/Views/metabox/_themosisRadioField.scout.php
@@ -1,4 +1,4 @@
-{{ Themosis\Facades\Form::radio($field['name'], $field['options'], $field['value'], array('data-field' => 'radio', 'id' => $field['name'].'-id', 'class' => $field['class'])) }}
+{{ Themosis\Facades\Form::radio($field['name'], $field['options'], $field['value'], array_merge(array('data-field' => 'radio', 'id' => $field['name'].'-id', 'class' => $field['class']), $field['attributes'])) }}
 
 @if(isset($field['info']))
     <div class="themosis-field-info">

--- a/src/Themosis/Field/Fields/Views/metabox/_themosisSelectField.scout.php
+++ b/src/Themosis/Field/Fields/Views/metabox/_themosisSelectField.scout.php
@@ -1,4 +1,4 @@
-{{ Themosis\Facades\Form::select($field['name'], $field['options'], $field['value'], array('multiple' => $field['multiple'], 'data-field' => 'select', 'id' => $field['id'], 'class' => $field['class'])) }}
+{{ Themosis\Facades\Form::select($field['name'], $field['options'], $field['value'], array_merge(array('multiple' => $field['multiple'], 'data-field' => 'select', 'id' => $field['id'], 'class' => $field['class']), $field['attributes'])) }}
 
 @if(isset($field['info']))
     <div class="themosis-field-info">

--- a/src/Themosis/Field/Fields/Views/metabox/_themosisTextField.scout.php
+++ b/src/Themosis/Field/Fields/Views/metabox/_themosisTextField.scout.php
@@ -1,4 +1,4 @@
-{{ Themosis\Facades\Form::text($field['name'], $field['value'], array('id' => $field['id'], 'class' => $field['class'], 'data-field' => 'text')) }}
+{{ Themosis\Facades\Form::text($field['name'], $field['value'], array_merge(array('id' => $field['id'], 'class' => $field['class'], 'data-field' => 'text'), $field['attributes'])) }}
 
 @if(isset($field['info']))
     <div class="themosis-field-info">

--- a/src/Themosis/Field/Fields/Views/metabox/_themosisTextareaField.scout.php
+++ b/src/Themosis/Field/Fields/Views/metabox/_themosisTextareaField.scout.php
@@ -1,4 +1,4 @@
-{{ Themosis\Facades\Form::textarea($field['name'], $field['value'], array('class' => $field['class'], 'data-field' => 'textarea', 'id' => $field['id'], 'rows' => '5')) }}
+{{ Themosis\Facades\Form::textarea($field['name'], $field['value'], array_merge(array('class' => $field['class'], 'data-field' => 'textarea', 'id' => $field['id'], 'rows' => '5'), $field['attributes'])) }}
 
 @if(isset($field['info']))
     <div class="themosis-field-info">


### PR DESCRIPTION
Hello, I needed read-only fields in metaboxes in the admin area, so I added this functionality - it allows setting html5 attributes (such as disabled, readonly, autocomplete, lang="en-GB" etc..) to input fields.

The support is added to the following field types:
- date
- checkbox (including the deprecated checkboxes)
- number
- password
- radio
- select
- textarea
- text

Example:
<pre>
Metabox::make('custom_feilds', 'post')->set(
    Field::text('my_sequence_id',array('attributes'=>array('readonly'))),
    Field::checkbox('my_options',array('0'=>'First option','2'=>'Second option'), array('attributes'=>array('disabled')),
    Field::number('my_min', array('attributes'=>array('min'=>10))),
);
</pre>