### PR TITLE
Meta::get should not rewrite https urls to httpss

### DIFF
--- a/src/Themosis/Metabox/Meta.php
+++ b/src/Themosis/Metabox/Meta.php
@@ -66,7 +66,7 @@ class Meta
 
 		} else {
 
-			if (0 === strpos($value, 'http')) {
+			if (0 === strpos($value, 'http') && 0 !== strpos($value, 'https')) {
 
 				if (static::isFromDomain($value)) {
 					


### PR DESCRIPTION
Meta::get changes first instance of http to https in a url when ssl is
on even if it is already an https url
Fix for issue: https://github.com/themosis/framework/issues/166