### PR TITLE
return an empty array if returned tags or terms is false

### DIFF
--- a/src/Themosis/View/Loop.php
+++ b/src/Themosis/View/Loop.php
@@ -34,6 +34,17 @@ class Loop
 	}
 
 	/**
+	 * Get author meta
+	 *
+	 * @param string $field
+	 * @return string
+	 */
+	public function authorMeta($field)
+	{
+		return get_the_author_meta($field)
+	}
+
+	/**
 	 * Get the content of the current post.
 	 *
 	 * @return string The content of the current post.

--- a/src/Themosis/View/Loop.php
+++ b/src/Themosis/View/Loop.php
@@ -41,7 +41,7 @@ class Loop
 	 */
 	public function authorMeta($field)
 	{
-		return get_the_author_meta($field)
+		return get_the_author_meta($field);
 	}
 
 	/**

--- a/src/Themosis/View/Loop.php
+++ b/src/Themosis/View/Loop.php
@@ -5,7 +5,7 @@ class Loop
 {
 	/**
 	 * Get the id of the current post.
-	 * 
+	 *
 	 * @return int The ID of the current post.
 	 */
 	public function id()
@@ -15,7 +15,7 @@ class Loop
 
 	/**
 	 * Get the title of the current post.
-	 * 
+	 *
 	 * @return string The title of the current post.
 	 */
 	public function title()
@@ -66,7 +66,7 @@ class Loop
 	{
 		return get_the_post_thumbnail($this->id(), $size, $attr);
 	}
-	
+
 	/**
 	 * Get thumbnail url of current post.
 	 *
@@ -109,7 +109,9 @@ class Loop
 	 */
 	public function tags()
 	{
-		return get_the_tags();
+		$tags = get_the_tags();
+
+		return $tags ? $tags : [];
 	}
 
 	/**
@@ -121,9 +123,11 @@ class Loop
 	 */
 	public function terms($taxonomy)
 	{
-		return get_the_terms($this->id(), $taxonomy);
+		$terms = get_the_terms($this->id(), $taxonomy);
+
+		return $terms ? $terms : [];
 	}
-	
+
 	/**
 	 * Get the date of the current post.
 	 *


### PR DESCRIPTION
This simplifies looping through tags or terms and not having to check if false is returned. So instead of 

```php
@if (Loop::tags())
    @foreach (Loop::tags())
        ...
    @endforeach
@endif
```

we simply have

```php
@foreach (Loop::tags())
    ...
@endforeach
```

There is still the issue of if WP_Error is returned