### PR TITLE
Add addMetaBox() method to post type class

### DIFF
--- a/src/Themosis/PostType/PostTypeBuilder.php
+++ b/src/Themosis/PostType/PostTypeBuilder.php
@@ -151,6 +151,16 @@ class PostTypeBuilder implements IPostType
     }
 
     /**
+     * Adds a new metabox to the custom post type
+     *
+     * @return \Themosis\Metabox\IMetabox
+     */
+    public function addMetaBox($title, $options = [], $view = null)
+    {
+        return $this->metabox->make($title, $this->datas['name'], $options = [], $view = null);
+    }
+
+    /**
      * Returns the custom post type slug name.
      *
      * @deprecated


### PR DESCRIPTION
This method allows a neater way to add meta boxes to custom post types.

It means instead of this:

```php
Metabox::make('Information', $books->get('name'))->set(array(
    Field::text('author'),
));
```

You can do this:

```php
$books->addMetaBox('Information')->set(array(
    Field::text('author'),
));
```

Seems a bit more OOP to me.