### PR TITLE
Fixed a bug caused by Laravel 5.4 new version

### DIFF
--- a/src/Themosis/Route/RouteCollection.php
+++ b/src/Themosis/Route/RouteCollection.php
@@ -13,7 +13,7 @@ class RouteCollection extends IlluminateRouteCollection
      */
     protected function addToCollections($route)
     {
-        $domainAndUri = $route->domain().$route->getUri();
+        $domainAndUri = $route->domain().$route->uri();
 
         if ($route->condition() && $route->conditionalParameters()) {
             $domainAndUri .= serialize($route->conditionalParameters());


### PR DESCRIPTION
This throws a "Call to undefined method Themosis\Route\Route::getUri()"
error.
The getUri() method needs to be changed to uri() in order to work with
Laravel 5.4.