### PR TITLE
Config ArrayAccess

### DIFF
--- a/src/Themosis/Config/ConfigFactory.php
+++ b/src/Themosis/Config/ConfigFactory.php
@@ -39,7 +39,7 @@ class ConfigFactory implements IConfig, ArrayAccess
         if (isset($property) && array_key_exists($property, $properties)) {
           // Looking for a single property in an array
           if (is_array($properties[$property])) {
-            return $this->getRecurisve(array_slice($parts, 1), $properties);
+            return $this->getRecursive(array_slice($parts, 1), $properties);
           }
           // Return the single property
           else {
@@ -91,7 +91,7 @@ class ConfigFactory implements IConfig, ArrayAccess
      *
      * @return mixed
      */
-    protected function getRecurisve(array $keys, array $array)
+    protected function getRecursive(array $keys, array $array)
     {
         foreach ($keys as $key) {
             if (array_key_exists($key, $array)) {

--- a/src/Themosis/Config/ConfigFactory.php
+++ b/src/Themosis/Config/ConfigFactory.php
@@ -2,7 +2,9 @@
 
 namespace Themosis\Config;
 
-class ConfigFactory implements IConfig
+use ArrayAccess;
+
+class ConfigFactory implements IConfig, ArrayAccess
 {
     /**
      * Config file finder instance.
@@ -26,17 +28,101 @@ class ConfigFactory implements IConfig
     public function get($name)
     {
         if (strpos($name, '.') !== false) {
-            list($name, $property) = explode('.', $name);
+            $parts = explode('.', $name);
+            list($name, $property) = $parts;
         }
 
         $path = $this->finder->find($name);
         $properties = include $path;
 
-        // Looking for single property
-        if (isset($property) && isset($properties[$property])) {
+        // Looking for a single property
+        if (isset($property) && array_key_exists($property, $properties)) {
+          // Looking for a single property in an array
+          if (is_array($properties[$property])) {
+            return $this->getRecurisve(array_slice($parts, 1), $properties);
+          }
+          // Return the single property
+          else {
             return $properties[$property];
+          }
+        }
+        // Return all properties
+        else {
+          return $properties;
+        }
+    }
+
+    /**
+     * Determines if an offset exists in a config for ArrayAccess
+     *
+     * @param  mixed  $offset
+     *
+     * @return  boolean
+     */
+    public function offsetExists($offset)
+    {
+      $value = $this->get($offset);
+
+      if ($value && !is_array($value)) {
+          return true;
+      }
+      else {
+          return false;
+      }
+    }
+
+    /**
+     * Returns an offset from the config for ArrayAccess interface
+     *
+     * @param  mixed  $offset
+     *
+     * @return  mixed
+     */
+    public function offsetGet($offset)
+    {
+        return $this->get($offset);
+    }
+
+    /**
+     * Recursively searches an array for a key
+     *
+     * @param  array  $keys
+     * @param  array  $array
+     *
+     * @return mixed
+     */
+    protected function getRecurisve(array $keys, array $array)
+    {
+        foreach ($keys as $key) {
+            if (array_key_exists($key, $array)) {
+                $array = $array[$key];
+            }
+            else {
+                return;
+            }
         }
 
-        return $properties;
+        return $array;
     }
+
+    /**
+     * Implementing for ArrayAccess, doesn't do anything because configs are read
+     * only.
+     *
+     * @param  mixed  $offset
+     * @param  mixed  $value
+     *
+     * @return void
+     */
+    public function offsetSet($offset, $value) {}
+
+    /**
+     * Implementing for ArrayAccess, doesn't do anything because configs are read
+     * only.
+     *
+     * @param  mixed  $offset
+     *
+     * @return void
+     */
+    public function offsetUnset($offset) {}
 }

--- a/src/Themosis/Config/ConfigFactory.php
+++ b/src/Themosis/Config/ConfigFactory.php
@@ -36,14 +36,16 @@ class ConfigFactory implements IConfig, ArrayAccess
         $properties = include $path;
 
         // Looking for a single property
-        if (isset($property) && array_key_exists($property, $properties)) {
-          // Looking for a single property in an array
-          if (is_array($properties[$property])) {
-            return $this->getRecursive(array_slice($parts, 1), $properties);
-          }
-          // Return the single property
-          else {
-            return $properties[$property];
+        if (isset($property)) {
+          if (array_key_exists($property, $properties)) {
+            // Looking for a single property in an array
+            if (is_array($properties[$property])) {
+              return $this->getRecursive(array_slice($parts, 1), $properties);
+            }
+            // Return the single property
+            else {
+              return $properties[$property];
+            }
           }
         }
         // Return all properties
@@ -63,7 +65,7 @@ class ConfigFactory implements IConfig, ArrayAccess
     {
       $value = $this->get($offset);
 
-      if ($value && !is_array($value)) {
+      if ($value) {
           return true;
       }
       else {

--- a/src/Themosis/Facades/Config.php
+++ b/src/Themosis/Facades/Config.php
@@ -27,7 +27,7 @@ class Config extends Facade implements ArrayAccess
      */
     public function offsetExists($offset)
     {
-      return self::offsetExists($offset);
+      return static::getInstance()->offsetExists($offset);
     }
 
     /**
@@ -39,7 +39,7 @@ class Config extends Facade implements ArrayAccess
      */
     public function offsetGet($offset)
     {
-        return self::offsetGet($offset);
+        return static::getInstance()->offsetGet($offset);
     }
 
     /**
@@ -53,7 +53,7 @@ class Config extends Facade implements ArrayAccess
      */
     public function offsetSet($offset, $value)
     {
-        self::offsetSet($offset, $value);
+        static::getInstance()->offsetSet($offset, $value);
     }
 
     /**
@@ -66,6 +66,6 @@ class Config extends Facade implements ArrayAccess
      */
     public function offsetUnset($offset)
     {
-        self::offsetSet($offset);
+        static::getInstance()->offsetUnset($offset);
     }
 }

--- a/src/Themosis/Facades/Config.php
+++ b/src/Themosis/Facades/Config.php
@@ -2,7 +2,9 @@
 
 namespace Themosis\Facades;
 
-class Config extends Facade
+use ArrayAccess;
+
+class Config extends Facade implements ArrayAccess
 {
     /**
      * Return the service provider key responsible for the config class.
@@ -14,5 +16,56 @@ class Config extends Facade
     protected static function getFacadeAccessor()
     {
         return 'config.factory';
+    }
+
+    /**
+     * Determines if an offset exists in a config for ArrayAccess
+     *
+     * @param  mixed  $offset
+     *
+     * @return  boolean
+     */
+    public function offsetExists($offset)
+    {
+      return self::offsetExists($offset);
+    }
+
+    /**
+     * Returns an offset from the config for ArrayAccess interface
+     *
+     * @param  mixed  $offset
+     *
+     * @return  mixed
+     */
+    public function offsetGet($offset)
+    {
+        return self::offsetGet($offset);
+    }
+
+    /**
+     * Implementing for ArrayAccess, doesn't do anything because configs are read
+     * only.
+     *
+     * @param  mixed  $offset
+     * @param  mixed  $value
+     *
+     * @return void
+     */
+    public function offsetSet($offset, $value)
+    {
+        self::offsetSet($offset, $value);
+    }
+
+    /**
+     * Implementing for ArrayAccess, doesn't do anything because configs are read
+     * only.
+     *
+     * @param  mixed  $offset
+     *
+     * @return void
+     */
+    public function offsetUnset($offset)
+    {
+        self::offsetSet($offset);
     }
 }

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -77,6 +77,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
     public function testArrayAccessOffsetExists()
     {
         $this->assertTrue(isset($this->factory['project.key']));
+        $this->assertTrue(isset($this->factory['project.multi-access']));
         $this->assertFalse(isset($this->factory['project.made-up']));
     }
 }

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -34,6 +34,9 @@ class ConfigTest extends PHPUnit_Framework_TestCase
                 'editor',
             ],
             'name' => 'themosis',
+            'multi-access' => [
+                'sub-key' => 'value',
+            ],
         ], $values);
 
         // Check return single value.
@@ -58,5 +61,22 @@ class ConfigTest extends PHPUnit_Framework_TestCase
         $theme = $this->factory->get('sample.theme');
 
         $this->assertEquals('Themosis Theme', $theme);
+    }
+
+    public function testGetMultiDimensionConfigValue()
+    {
+        $this->assertEquals('value', $this->factory->get('project.multi-access.sub-key'));
+    }
+
+    public function testArrayAccessOffsetGet()
+    {
+        $this->assertEquals('value', $this->factory['project.key']);
+        $this->assertEquals('value', $this->factory['project.multi-access.sub-key']);
+    }
+
+    public function testArrayAccessOffsetExists()
+    {
+        $this->assertTrue(isset($this->factory['project.key']));
+        $this->assertFalse(isset($this->factory['project.made-up']));
     }
 }

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -35,7 +35,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
             ],
             'name' => 'themosis',
             'multi-access' => [
-                'sub-key' => 'value',
+                'key' => 'value2',
             ],
         ], $values);
 
@@ -65,13 +65,13 @@ class ConfigTest extends PHPUnit_Framework_TestCase
 
     public function testGetMultiDimensionConfigValue()
     {
-        $this->assertEquals('value', $this->factory->get('project.multi-access.sub-key'));
+        $this->assertEquals('value2', $this->factory->get('project.multi-access.key'));
     }
 
     public function testArrayAccessOffsetGet()
     {
         $this->assertEquals('value', $this->factory['project.key']);
-        $this->assertEquals('value', $this->factory['project.multi-access.sub-key']);
+        $this->assertEquals('value2', $this->factory['project.multi-access.key']);
     }
 
     public function testArrayAccessOffsetExists()

--- a/tests/Config/configFiles/project.config.php
+++ b/tests/Config/configFiles/project.config.php
@@ -8,6 +8,6 @@ return [
     ],
     'name' => 'themosis',
     'multi-access' => [
-        'sub-key' => 'value',
+        'key' => 'value2',
     ],
 ];

--- a/tests/Config/configFiles/project.config.php
+++ b/tests/Config/configFiles/project.config.php
@@ -7,4 +7,7 @@ return [
         'editor',
     ],
     'name' => 'themosis',
+    'multi-access' => [
+        'sub-key' => 'value',
+    ],
 ];


### PR DESCRIPTION
Ref #372 

Implemented with tests, I've also changed it so that it will traverse arrays to search for multidot properties (e.g. 'project.multi-access.sub-key'), I don't think that'll be a breaking change as currently you'd have to do: -

```
$vals = Config::get('project.multi-access');
$val  = $vals['sub-key'];
```

This is a quick fix but I still think it's worth refactoring to use the Illuminate/Config package like you originally said.