### PR TITLE
Simplification of PostTypeBuilder + TaxonomyBuilder

### DIFF
--- a/src/Themosis/PostType/PostTypeBuilder.php
+++ b/src/Themosis/PostType/PostTypeBuilder.php
@@ -7,6 +7,7 @@ use Themosis\Foundation\Application;
 use Themosis\Foundation\DataContainer;
 use Themosis\Hook\IHook;
 use Themosis\Metabox\IMetabox;
+use Doctrine\Common\Inflector\Inflector;
 
 class PostTypeBuilder implements IPostType
 {
@@ -102,6 +103,10 @@ class PostTypeBuilder implements IPostType
      */
     public function make($name, $plural, $singular)
     {
+        
+        $plural = $plural ? $plural : Inflector::pluralize($name);
+	    $singular = $singular ? $singular : Inflector::singularize($name);
+        
         $params = compact('name', 'plural', 'singular');
 
         foreach ($params as $key => $param) {

--- a/src/Themosis/PostType/PostTypeBuilder.php
+++ b/src/Themosis/PostType/PostTypeBuilder.php
@@ -101,11 +101,11 @@ class PostTypeBuilder implements IPostType
      *
      * @return \Themosis\PostType\PostTypeBuilder
      */
-    public function make($name, $plural, $singular)
+    public function make($name, $plural = false, $singular = false)
     {
         
         $plural = $plural ? $plural : Inflector::pluralize($name);
-	    $singular = $singular ? $singular : Inflector::singularize($name);
+	$singular = $singular ? $singular : Inflector::singularize($name);
         
         $params = compact('name', 'plural', 'singular');
 

--- a/src/Themosis/Taxonomy/TaxonomyBuilder.php
+++ b/src/Themosis/Taxonomy/TaxonomyBuilder.php
@@ -8,6 +8,7 @@ use Themosis\Foundation\DataContainer;
 use Themosis\Field\Wrapper;
 use Themosis\Hook\IHook;
 use Themosis\Validation\ValidationBuilder;
+use Doctrine\Common\Inflector\Inflector;
 
 class TaxonomyBuilder extends Wrapper
 {
@@ -78,8 +79,12 @@ class TaxonomyBuilder extends Wrapper
      *
      * @return \Themosis\Taxonomy\TaxonomyBuilder
      */
-    public function make($name, $postType, $plural, $singular)
+    public function make($name, $postType, $plural = false, $singular = false)
     {
+        
+        $plural = $plural ? $plural : Inflector::pluralize($name);
+	    $singular = $singular ? $singular : Inflector::singularize($name);
+        
         $params = compact('name', 'postType', 'plural', 'singular');
 
         foreach ($params as $key => $param) {


### PR DESCRIPTION
To make the process simpler by requiring the least number of arguments. Doctrine\Inflector is a dependancy of Illuminate\Support so we don't need to worry about importing this.

This is first time I am contributing, I am not sure if this is classed as a minor feature, if so I can push this to v 1.3 branch if you wish.