### PR TITLE
Accepting integer as selected value type

### DIFF
--- a/src/Themosis/Html/FormBuilder.php
+++ b/src/Themosis/Html/FormBuilder.php
@@ -627,7 +627,7 @@ class FormBuilder
 
         // Deal single selection.
         // $key might be an int or a string
-        if (is_string($value) && $key == $value) {
+        if (is_string($value) || is_integer($value) && $key == $value) {
             return $selected;
         }
 


### PR DESCRIPTION
In some cases we receive the data dynamically so it's hard and dangerous to cast an integer to a string, for example. And since we're working with equals comparison instead of an identical comparison the default behaviour will be the same.

Scenario example:
```
$selected = 2009;
Form::select('year', [['2009','2010','2011']], $selected);
``` 