### PR TITLE
Remove usage of sanitize_user for password sanitization.

### DIFF
--- a/src/Themosis/User/UserFactory.php
+++ b/src/Themosis/User/UserFactory.php
@@ -93,7 +93,7 @@ class UserFactory extends Wrapper implements IUser
 
         // Clean credentials.
         $username = sanitize_user($username, true);
-        $password = sanitize_user($password);
+        $password = trim($password);
         $email = sanitize_email($email);
 
         // Create a WordPress in the database.


### PR DESCRIPTION
The usage of sanitize_user will transform all uppercase characters to lowercase and will therefore make it impossible to create passwords with uppercase characters.
If you have specific password requirements like password length and/or allowed characters you can use the Validation class to enforce this yourself before calling User::make().