### PR TITLE
Add support for attaching metaboxes to multiple templates

### DIFF
--- a/src/Themosis/Metabox/MetaboxBuilder.php
+++ b/src/Themosis/Metabox/MetaboxBuilder.php
@@ -339,7 +339,7 @@ class MetaboxBuilder extends Wrapper implements IMetabox
             $template = get_post_meta($postID, '_wp_page_template', true);
 
             // Check if a template is attached to the post/page.
-            if ($template == $this->datas['options']['template']) {
+            if (in_array($template, $this->datas['options']['template'], true)) {
                 // Add a metabox for post/pages with a registered template.
                 $this->addMetabox();
             }


### PR DESCRIPTION
I frequently have Metabox sections that I want to be accessible on multiple templates, this PR adds support for this feature using Metabox options. 

For semantic reasons, I used `in_array()` and changed each of my Metaboxes template option to an array. 

To note: this is a breaking change. If backwards compatibility is needed this feature can be easily added with a `strpos()`, although that would introduce potential partial matching issues on more generic template slugs. 

I apologize if this feature is implemented with a different approach, but I was not able to find any documentation available on assigning metaboxes to more than one template. 

Thank you for your time, please let me know if there's an update you would like made to this PR. 