### PR TITLE
Fix mu-plugins not loading on windows

### DIFF
--- a/src/Core/Application.php
+++ b/src/Core/Application.php
@@ -1179,7 +1179,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     {
         $directories = Collection::make((new Filesystem())->directories($this->mupluginsPath()))
             ->map(function ($directory) {
-                return ltrim(substr($directory, strrpos($directory, '/')), '\/');
+                return ltrim(substr($directory, strrpos($directory, DS)), '\/');
             })->toArray();
 
         (new PluginsRepository($this, new Filesystem(), $pluginsPath, $this->getCachedPluginsPath()))


### PR DESCRIPTION
the DIRECTORY_SEPARATOR constant
will return the right separator for the OS.

fixes #558 