### PR TITLE
[FIX] Finder not finding on Windows

### DIFF
--- a/src/Asset/Finder.php
+++ b/src/Asset/Finder.php
@@ -36,7 +36,7 @@ class Finder
      */
     public function addLocation(string $path, string $url): Finder
     {
-        $path = '/'.trim($path, '\/');
+        $path = rtrim($path, '\/');
         $url = rtrim($url, '\/');
 
         $this->locations[$path] = $url;


### PR DESCRIPTION
fixes #560 
the hardcoded `/` will result in paths like this on Windows:
`/C:\\path\example`

I suggest to use rtrim to remove the slash at the end of the path,
but not touch the slash in the beginning (if one is given).

I tested this both on Windows 10 and Ubuntu and it caused no issues in my use case.