### PR TITLE
Bugfix/issue 560

### DIFF
--- a/src/Asset/Finder.php
+++ b/src/Asset/Finder.php
@@ -36,7 +36,7 @@ class Finder
      */
     public function addLocation(string $path, string $url): Finder
     {
-        $path = '/'.trim($path, '\/');
+        $path = rtrim($path, '\/');
         $url = rtrim($url, '\/');
 
         $this->locations[$path] = $url;

--- a/src/Asset/Finder.php
+++ b/src/Asset/Finder.php
@@ -37,6 +37,8 @@ class Finder
     public function addLocation(string $path, string $url): Finder
     {
         $path = rtrim($path, '\/');
+        if( !path_is_absolute($path) )
+            $path = DS.$path;
         $url = rtrim($url, '\/');
 
         $this->locations[$path] = $url;


### PR DESCRIPTION
This way paths in the finder always start with a / unless it's one of those silly windows paths that start with something like `C:/`.
thoughts?

fixes #560 