### PR TITLE
Bugfix/windows fixes

### DIFF
--- a/src/Core/PluginManager.php
+++ b/src/Core/PluginManager.php
@@ -87,7 +87,7 @@ class PluginManager
      */
     public function setDirectory()
     {
-        $pos = strrpos($this->dirPath, '/');
+        $pos = strrpos($this->dirPath, DS);
         $this->directory = substr($this->dirPath, $pos + 1);
     }
 

--- a/src/Core/ThemeManager.php
+++ b/src/Core/ThemeManager.php
@@ -181,7 +181,7 @@ class ThemeManager
      */
     protected function setThemeDirectory()
     {
-        $pos = strrpos($this->dirPath, '/');
+        $pos = strrpos($this->dirPath, DS);
 
         $this->directory = substr($this->dirPath, $pos + 1);
     }

--- a/tests/Assets/AssetsTest.php
+++ b/tests/Assets/AssetsTest.php
@@ -43,22 +43,22 @@ class AssetsTest extends TestCase
         $finder = new Finder(new Filesystem());
 
         $finder->addLocation(
-            '/home/www/htdocs/content/themes/themosis/dist',
+            DS.'home'.DS.'www'.DS.'htdocs'.DS.'content'.DS.'themes'.DS.'themosis'.DS.'dist',
             'https://www.website.com/content/themes/themosis/dist'
         );
 
         $finder->addLocations([
-            'www/resources' => 'http://example.com/resources/',
-            'public/assets/' => 'https://wordpress.xyz/assets',
-            '/public/dist' => 'http://sub.domain.com/dist/'
+            'www'.DS.'resources' => 'http://example.com/resources/',
+            'public'.DS.'assets'.DS => 'https://wordpress.xyz/assets',
+            DS.'public'.DS.'dist' => 'http://sub.domain.com/dist/'
         ]);
 
         $this->assertEquals(
             [
-                '/home/www/htdocs/content/themes/themosis/dist',
-                '/www/resources',
-                '/public/assets',
-                '/public/dist'
+                DS.'home'.DS.'www'.DS.'htdocs'.DS.'content'.DS.'themes'.DS.'themosis'.DS.'dist',
+                DS.'www'.DS.'resources',
+                DS.'public'.DS.'assets',
+                DS.'public'.DS.'dist'
             ],
             array_keys($finder->getLocations())
         );

--- a/tests/Core/ApplicationTest.php
+++ b/tests/Core/ApplicationTest.php
@@ -26,7 +26,7 @@ class ApplicationTest extends TestCase
         $app = new Application($path);
 
         $this->assertEquals(
-            $path.'/app',
+            $path.DS.'app',
             $app['path'],
             'Cannot get the default path'
         );
@@ -36,41 +36,41 @@ class ApplicationTest extends TestCase
             'Cannot get the base path'
         );
         $this->assertEquals(
-            $path.'/htdocs/content',
+            $path.DS.'htdocs'.DS.'content',
             $app['path.content'],
             'Cannot get the content path'
         );
         $this->assertEquals(
-            $path.'/htdocs/content/mu-plugins',
+            $path.DS.'htdocs'.DS.'content'.DS.'mu-plugins',
             $app['path.muplugins'],
             'Cannot get the mu-plugins path'
         );
         $this->assertEquals(
-            $path.'/htdocs/content/plugins',
+            $path.DS.'htdocs'.DS.'content'.DS.'plugins',
             $app['path.plugins'],
             'Cannot get the plugins path'
         );
         $this->assertEquals(
-            $path.'/htdocs/content/themes',
+            $path.DS.'htdocs'.DS.'content'.DS.'themes',
             $app['path.themes'],
             'Cannot get the themes path'
         );
         $this->assertEquals(
-            $path.'/app',
+            $path.DS.'app',
             $app['path.application'],
             'Cannot get the app path'
         );
         $this->assertEquals(
-            $path.'/resources',
+            $path.DS.'resources',
             $app['path.resources']
         );
         $this->assertEquals(
-            $path.'/resources/languages',
+            $path.DS.'resources'.DS.'languages',
             $app['path.lang'],
             'Cannot get the languages path'
         );
         $this->assertEquals(
-            $path.'/htdocs',
+            $path.DS.'htdocs',
             $app['path.web'],
             'Cannot get the web path'
         );
@@ -80,32 +80,32 @@ class ApplicationTest extends TestCase
             'Cannot get the root path'
         );
         $this->assertEquals(
-            $path.'/config',
+            $path.DS.'config',
             $app['path.config'],
             'Cannot get the defaut config path'
         );
         $this->assertEquals(
-            $path.'/htdocs',
+            $path.DS.'htdocs',
             $app['path.public'],
             'Cannot get the public path'
         );
         $this->assertEquals(
-            $path.'/storage',
+            $path.DS.'storage',
             $app['path.storage'],
             'Cannot get the storage path'
         );
         $this->assertEquals(
-            $path.'/database',
+            $path.DS.'database',
             $app['path.database'],
             'Cannot get the database path'
         );
         $this->assertEquals(
-            $path.'/bootstrap',
+            $path.DS.'bootstrap',
             $app['path.bootstrap'],
             'Cannot get the bootstrap path'
         );
         $this->assertEquals(
-            $path.'/htdocs/cms',
+            $path.DS.'htdocs'.DS.'cms',
             $app['path.wp'],
             'Cannot get the WordPress path'
         );

--- a/tests/Core/PluginManagerTest.php
+++ b/tests/Core/PluginManagerTest.php
@@ -43,7 +43,7 @@ class PluginManagerTest extends TestCase
         $this->assertEquals($this->getApplication()->pluginsPath('timeline'), $plugin->getPath());
         $this->assertTrue(defined('TIMELINE_TD'));
 
-        $this->assertEquals($this->getApplication()->pluginsPath('timeline/dist'), $plugin->getPath('dist'));
+        $this->assertEquals($this->getApplication()->pluginsPath('timeline'.DS.'dist'), $plugin->getPath('dist'));
     }
 
     public function testPluginHeaders()


### PR DESCRIPTION
Replaced all slashes with the Directory Separator constant (DS) to stop failures on Windows.

Tests were OK on both Windows 10 and Ubuntu for me.

Maybe it'd be worth it to add a function to convert any path to one correct for the current OS.
