### PR TITLE
fix `composer test` on windows

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
     "symfony/var-dumper": "^4.1"
   },
   "scripts": {
-    "test": "php ./vendor/bin/phpunit"
+    "test": "phpunit"
   },
   "config": {
     "sort-packages": true


### PR DESCRIPTION
`php ./vendor/bin/phpunit` is not going to work on Windows, because phpunit is not supposed to be run with PHP.  
You don't have to specify `/vendor/bin/` in scripts, composer does this automatically.

see:
https://getcomposer.org/doc/articles/scripts.md#writing-custom-commands