### PR TITLE
fix class Facade not found error in Facades

### DIFF
--- a/src/Support/Facades/Config.php
+++ b/src/Support/Facades/Config.php
@@ -2,6 +2,8 @@
 
 namespace Themosis\Facades;
 
+use Illuminate\Support\Facades\Facade;
+
 class Config extends Facade
 {
     /**

--- a/src/Support/Facades/DB.php
+++ b/src/Support/Facades/DB.php
@@ -2,6 +2,8 @@
 
 namespace Themosis\Facades;
 
+use Illuminate\Support\Facades\Facade;
+
 class DB extends Facade
 {
     /**

--- a/src/Support/Facades/Input.php
+++ b/src/Support/Facades/Input.php
@@ -2,6 +2,8 @@
 
 namespace Themosis\Facades;
 
+use Illuminate\Support\Facades\Facade;
+
 class Input extends Facade
 {
     /**

--- a/src/Support/Facades/Request.php
+++ b/src/Support/Facades/Request.php
@@ -2,6 +2,8 @@
 
 namespace Themosis\Facades;
 
+use Illuminate\Support\Facades\Facade;
+
 class Request extends Facade
 {
     /**

--- a/src/Support/Facades/Section.php
+++ b/src/Support/Facades/Section.php
@@ -2,6 +2,8 @@
 
 namespace Themosis\Facades;
 
+use Illuminate\Support\Facades\Facade;
+
 class Section extends Facade
 {
     /**

--- a/src/Support/Facades/User.php
+++ b/src/Support/Facades/User.php
@@ -2,6 +2,8 @@
 
 namespace Themosis\Facades;
 
+use Illuminate\Support\Facades\Facade;
+
 class User extends Facade
 {
     /**

--- a/src/Support/Facades/Validator.php
+++ b/src/Support/Facades/Validator.php
@@ -2,6 +2,8 @@
 
 namespace Themosis\Facades;
 
+use Illuminate\Support\Facades\Facade;
+
 class Validator extends Facade
 {
     /**


### PR DESCRIPTION
not every facade contains the `use` statement for the Facade class,
causing class not-found errors.
