### PR TITLE
add THEME_DP constant

### DIFF
--- a/src/Core/Support/WordPressFileHeaders.php
+++ b/src/Core/Support/WordPressFileHeaders.php
@@ -21,7 +21,7 @@ trait WordPressFileHeaders
             if (preg_match('/^[ \t\/*#@]*'.preg_quote($regex, '/').':(.*)$/mi', $data, $match) && $match[1]) {
                 $properties[$field] = trim(preg_replace("/\s*(?:\*\/|\?>).*/", '', $match[1]));
             } else {
-                $properties[$field] = null;
+                $properties[$field] = '';
             }
         }
 

--- a/src/Core/Support/WordPressFileHeaders.php
+++ b/src/Core/Support/WordPressFileHeaders.php
@@ -21,7 +21,7 @@ trait WordPressFileHeaders
             if (preg_match('/^[ \t\/*#@]*'.preg_quote($regex, '/').':(.*)$/mi', $data, $match) && $match[1]) {
                 $properties[$field] = trim(preg_replace("/\s*(?:\*\/|\?>).*/", '', $match[1]));
             } else {
-                $properties[$field] = '';
+                $properties[$field] = null;
             }
         }
 

--- a/src/Core/ThemeManager.php
+++ b/src/Core/ThemeManager.php
@@ -57,7 +57,8 @@ class ThemeManager
         'version' => 'Version',
         'license' => 'License',
         'license_uri' => 'License URI',
-        'text_domain' => 'Text Domain'
+        'text_domain' => 'Text Domain',
+        'domain_path' => 'Domain Path',
     ];
 
     /**
@@ -263,7 +264,10 @@ class ThemeManager
 
         // Theme text domain.
         $textdomain = $this->parsedHeaders['text_domain'] ?? 'themosis_theme';
+        $domainpath = $this->parsedHeaders['domain_path'] ?? 'languages';
+        
         defined('THEME_TD') ? THEME_TD : define('THEME_TD', $textdomain);
+        defined('THEME_DP') ? THEME_DP : define('THEME_DP', $domainpath);
     }
 
     /**

--- a/src/Core/ThemeManager.php
+++ b/src/Core/ThemeManager.php
@@ -264,10 +264,8 @@ class ThemeManager
 
         // Theme text domain.
         $textdomain = $this->parsedHeaders['text_domain'] ?? 'themosis_theme';
-        $domainpath = $this->parsedHeaders['domain_path'] ?? 'languages';
         
         defined('THEME_TD') ? THEME_TD : define('THEME_TD', $textdomain);
-        defined('THEME_DP') ? THEME_DP : define('THEME_DP', $domainpath);
     }
 
     /**

--- a/src/Core/ThemeManager.php
+++ b/src/Core/ThemeManager.php
@@ -263,7 +263,9 @@ class ThemeManager
         $this->parsedHeaders = $this->headers($this->dirPath.'/style.css', $this->headers);
 
         // Theme text domain.
-        $textdomain = $this->parsedHeaders['text_domain'] ?? 'themosis_theme';
+        $textdomain = (isset($this->parsedHeaders['text_domain']) && ! empty($this->parsedHeaders['text_domain']))
+            ? $this->parsedHeaders['text_domain']
+            : 'themosis_theme';
         
         defined('THEME_TD') ? THEME_TD : define('THEME_TD', $textdomain);
     }


### PR DESCRIPTION
and after that it will be necessary to replace in `themosis/theme/functions.php` the function call
  
```php
load_theme_textdomain(THEME_TD, $theme->getPath('languages'));
```

on this

```php
load_theme_textdomain(THEME_TD, $theme->getPath(THEME_DP));
```

As a result, we will be able to easily change the location of `languages` ​​by simply changing the path in the parameter “Domain path: languages” in the file of `themosis/theme/style.css`

At the moment, if you change the path in the `themosis/theme/functions.php` without explicit instructions in the `theme/theme/style.css`, **PoEdit** gives an error if there is no .pot file.

This PR solves this problem ...