### PR TITLE
dd() and dump() functions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,12 +56,12 @@
     "illuminate/view": "5.7.*",
     "league/flysystem": "^1.0",
     "league/fractal": "^0.17.0",
+    "symfony/var-dumper": "^4.1",
     "twig/twig": " ^2.0",
     "vlucas/phpdotenv": "^2.4"
   },
   "require-dev": {
-    "phpunit/phpunit": "^7.0",
-    "symfony/var-dumper": "^4.1"
+    "phpunit/phpunit": "^7.0"
   },
   "scripts": {
     "test": "phpunit"

--- a/src/Core/helpers.php
+++ b/src/Core/helpers.php
@@ -11,6 +11,7 @@ use Illuminate\Log\LogManager;
 use Illuminate\Routing\Redirector;
 use Illuminate\Support\HtmlString;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\VarDumper\VarDumper;
 
 if (! function_exists('app')) {
     /**
@@ -447,5 +448,23 @@ if (! function_exists('web_path')) {
     function web_path($path = '')
     {
         return app()->webPath($path);
+    }
+}
+
+if (! function_exists('dump')) {
+    function dump()
+    {
+        $args = func_get_args();
+        foreach ($args as $arg) {
+            VarDumper::dump($arg);
+        }
+    }
+}
+
+if (! function_exists('dd')) {
+    function dd(...$args)
+    {
+        call_user_func_array('dump', $args);
+        die(1);
     }
 }


### PR DESCRIPTION
These are functions taken from Laravel.

`dump()` uses Symfony's [VarDumper](https://symfony.com/doc/current/components/var_dumper.html) to output variables in a readable way.  
`dd()` calls `dump()` and then `die`.

I noticed `td()` doesn't work in Themosis 2.0^ anymore.
I always really liked Symfony's VarDumper and I think all developers could benefit from having the `dd()` function available.
