### PR TITLE
Fix .maintenance path in Down and Up commands

### DIFF
--- a/src/Core/Console/DownCommand.php
+++ b/src/Core/Console/DownCommand.php
@@ -26,7 +26,7 @@ class DownCommand extends Command
     public function handle()
     {
         file_put_contents(
-            web_path('/cms/.maintenance'),
+            web_path(config('app.wp.dir').'/.maintenance'),
             '<?php $upgrading = '.$this->getDuration().'; ?>'
         );
 

--- a/src/Core/Console/UpCommand.php
+++ b/src/Core/Console/UpCommand.php
@@ -25,7 +25,7 @@ class UpCommand extends Command
      */
     public function handle()
     {
-        @unlink(web_path('/cms/.maintenance'));
+        @unlink(web_path(config('app.wp.dir').'/.maintenance'));
 
         $this->info('Application is now live.');
     }


### PR DESCRIPTION
The Down and Up commands failing because of the wrong path for the `.maintenance` file (ref. https://github.com/themosis/framework/issues/607). Here the screenshot:

![screenshot](https://snag.gy/gBHxyb.jpg)

This solution works on my end, I hope it works for you as well.