### PR TITLE
Add laravel mix helper

### DIFF
--- a/src/Core/ThemeManager.php
+++ b/src/Core/ThemeManager.php
@@ -383,45 +383,45 @@ class ThemeManager
         return $this;
     }
 
-	/**
+    /**
      * Register load theme assets dynamically
-	 * $theme->mix('dist/css/app.css');
+     * $theme->mix('dist/css/app.css');
      *
      * @param array $templates
      *
      * @return $this
      */
 
-	function mix($path, $manifest = false, $shouldHotReload = false)
-	{
-		if (! $manifest) static $manifest;
-		if (! $shouldHotReload) static $shouldHotReload;
+    function mix($path, $manifest = false, $shouldHotReload = false)
+    {
+        if (! $manifest) static $manifest;
+        if (! $shouldHotReload) static $shouldHotReload;
 
-		if (! $manifest) {
-			$manifestPath = $this->dirPath . '/mix-manifest.json';
-			$shouldHotReload = file_exists($this->dirPath . '/hot');
+        if (! $manifest) {
+            $manifestPath = $this->dirPath . '/mix-manifest.json';
+            $shouldHotReload = file_exists($this->dirPath . '/hot');
 
-			if (! file_exists($manifestPath)) {
-				throw new \Exception(
-					'The Laravel Mix manifest file does not exist. ' .
-					'Please run "npm run webpack" and try again.'
-				);
-			}
+            if (! file_exists($manifestPath)) {
+                throw new \Exception(
+                    'The Laravel Mix manifest file does not exist. ' .
+                    'Please run "npm run webpack" and try again.'
+                );
+            }
 
-			$manifest = json_decode(file_get_contents($manifestPath), true);
-		}
+            $manifest = json_decode(file_get_contents($manifestPath), true);
+        }
 
-		if (! starts_with($path, '/')) $path = "/{$path}";
+        if (! starts_with($path, '/')) $path = "/{$path}";
 
-		if (! array_key_exists($path, $manifest)) {
-			throw new \Exception(
-				"Unknown Laravel Mix file path: {$path}. Please check your requested " .
-				"webpack.mix.js output path, and try again."
-			);
-		}
+        if (! array_key_exists($path, $manifest)) {
+            throw new \Exception(
+                "Unknown Laravel Mix file path: {$path}. Please check your requested " .
+                "webpack.mix.js output path, and try again."
+            );
+        }
 
-		return $shouldHotReload
-			? "http://localhost:8080{$manifest[$path]}"
-			: $this->getUrl(ltrim($manifest[$path], '/'));
-	}
+        return $shouldHotReload
+            ? "http://localhost:8080{$manifest[$path]}"
+            : $this->getUrl(ltrim($manifest[$path], '/'));
+    }
 }

--- a/src/Core/ThemeManager.php
+++ b/src/Core/ThemeManager.php
@@ -382,4 +382,46 @@ class ThemeManager
 
         return $this;
     }
+
+	/**
+     * Register load theme assets dynamically
+	 * $theme->mix('dist/css/app.css');
+     *
+     * @param array $templates
+     *
+     * @return $this
+     */
+
+	function mix($path, $manifest = false, $shouldHotReload = false)
+	{
+		if (! $manifest) static $manifest;
+		if (! $shouldHotReload) static $shouldHotReload;
+
+		if (! $manifest) {
+			$manifestPath = $this->dirPath . '/mix-manifest.json';
+			$shouldHotReload = file_exists($this->dirPath . '/hot');
+
+			if (! file_exists($manifestPath)) {
+				throw new \Exception(
+					'The Laravel Mix manifest file does not exist. ' .
+					'Please run "npm run webpack" and try again.'
+				);
+			}
+
+			$manifest = json_decode(file_get_contents($manifestPath), true);
+		}
+
+		if (! starts_with($path, '/')) $path = "/{$path}";
+
+		if (! array_key_exists($path, $manifest)) {
+			throw new \Exception(
+				"Unknown Laravel Mix file path: {$path}. Please check your requested " .
+				"webpack.mix.js output path, and try again."
+			);
+		}
+
+		return $shouldHotReload
+			? "http://localhost:8080{$manifest[$path]}"
+			: $this->getUrl(ltrim($manifest[$path], '/'));
+	}
 }

--- a/tests/Core/ThemeManagerTest.php
+++ b/tests/Core/ThemeManagerTest.php
@@ -130,11 +130,11 @@ class ThemeManagerTest extends TestCase
     public function testThemeManagerCanHandleMixManifest()
     {
         $app = $this->getApplication();
-		$theme = $this->getThemeManager();
-		$theme = $theme->load($app->themesPath('underscore/config'));
+        $theme = $this->getThemeManager();
+        $theme = $theme->load($app->themesPath('underscore/config'));
 
-		$this->assertEquals(
-			$theme->mix('dist/css/theme.css'), $theme->getUrl('dist/css/theme.css?id=ba9aead02aea5cc7befb')
-		);
+        $this->assertEquals(
+            $theme->mix('dist/css/theme.css'), $theme->getUrl('dist/css/theme.css?id=ba9aead02aea5cc7befb')
+        );
     }
 }

--- a/tests/Core/ThemeManagerTest.php
+++ b/tests/Core/ThemeManagerTest.php
@@ -126,4 +126,15 @@ class ThemeManagerTest extends TestCase
         $this->assertTrue(defined('THEME_MANAGER_INC'));
         $this->assertTrue(defined('THEME_MANAGER_NESTED_INC'));
     }
+
+    public function testThemeManagerCanHandleMixManifest()
+    {
+        $app = $this->getApplication();
+		$theme = $this->getThemeManager();
+		$theme = $theme->load($app->themesPath('underscore/config'));
+
+		$this->assertEquals(
+			$theme->mix('dist/css/theme.css'), $theme->getUrl('dist/css/theme.css?id=ba9aead02aea5cc7befb')
+		);
+    }
 }

--- a/tests/functions.php
+++ b/tests/functions.php
@@ -202,12 +202,12 @@ function is_custom($num)
 
 function is_multisite()
 {
-	return false;
+    return false;
 }
 
 function get_template_directory_uri()
 {
-	return '/tests/htdocs/content/themes/underscore/';
+    return '/tests/htdocs/content/themes/underscore/';
 }
 
 /*

--- a/tests/functions.php
+++ b/tests/functions.php
@@ -200,6 +200,16 @@ function is_custom($num)
     return false;
 }
 
+function is_multisite()
+{
+	return false;
+}
+
+function get_template_directory_uri()
+{
+	return '/tests/htdocs/content/themes/underscore/';
+}
+
 /*
 |--------------------------------------------------------------------------
 | Callback Handler

--- a/tests/htdocs/content/themes/underscore/mix-manifest.json
+++ b/tests/htdocs/content/themes/underscore/mix-manifest.json
@@ -1,0 +1,5 @@
+{
+	"/dist/js/theme.min.js": "/dist/js/theme.min.js?id=bf37ccc8bbe248fe79e1",
+	"/dist/css/theme.css": "/dist/css/theme.css?id=ba9aead02aea5cc7befb",
+	"/dist/css/woocommerce.css": "/dist/css/woocommerce.css?id=edc42852683a037481e7"
+}


### PR DESCRIPTION
When you run Laravel mix with versioning enabled you need to grab the files a bit more dynamically. 

With this PR you can add the following to the theme repo:

```js
// webpack.mix.js
if (mix.inProduction()) {
	mix.version();
}
```
```php
// AssetServiceProvider.php
public function register()
{
	/** @var ThemeManager $theme */
	$theme = $this->app->make('wp.theme');
	
	Asset::add('theme_styles', $theme->mix('dist/css/theme.css'), [], $theme->getHeader('version'))
		->setType('css')->to('front');

	Asset::add('theme_woo', $theme->mix('dist/css/woocommerce.css'), ['theme_styles'], $theme->getHeader('version'))
		->setType('css')->to('front');

	Asset::add('theme_js', $theme->mix('dist/js/theme.min.js'), [], $theme->getHeader('version'))
		->setType('js')->to('front');
}
```