### PR TITLE
Allow directories without main file in mu-plugins

### DIFF
--- a/src/Core/PluginsRepository.php
+++ b/src/Core/PluginsRepository.php
@@ -85,7 +85,9 @@ class PluginsRepository
             // As we load the plugins from the mu-plugins directory
             // we do not need to get their header. Only the file
             // that defines them.
-            $manifest[$directory] = $this->getPlugin($directory);
+            if ($payload = $this->getPlugin($directory)) {
+                $manifest[$directory] = $payload;
+            }
         }
 
         return $this->writeManifest($manifest);


### PR DESCRIPTION
Ref. https://github.com/themosis/framework/issues/628

It should fix the problem explained in the issue, skipping the folders that don't have the main PHP file.