### PR TITLE
missing middleware methods in kernel

### DIFF
--- a/src/Core/Http/Kernel.php
+++ b/src/Core/Http/Kernel.php
@@ -128,6 +128,17 @@ class Kernel implements \Illuminate\Contracts\Http\Kernel
     }
 
     /**
+     * Determine if the kernel has a given middleware.
+     *
+     * @param  string  $middleware
+     * @return bool
+     */
+    public function hasMiddleware($middleware)
+    {
+        return in_array($middleware, $this->middleware);
+    }
+
+    /**
      * Send given request through the middleware (if any) and router.
      *
      * @param \Illuminate\Http\Request $request
@@ -252,6 +263,36 @@ class Kernel implements \Illuminate\Contracts\Http\Kernel
     }
 
     /**
+     * Add a new middleware to beginning of the stack if it does not already exist.
+     *
+     * @param  string  $middleware
+     * @return $this
+     */
+    public function prependMiddleware($middleware)
+    {
+        if (array_search($middleware, $this->middleware) === false) {
+            array_unshift($this->middleware, $middleware);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add a new middleware to end of the stack if it does not already exist.
+     *
+     * @param  string  $middleware
+     * @return $this
+     */
+    public function pushMiddleware($middleware)
+    {
+        if (array_search($middleware, $this->middleware) === false) {
+            $this->middleware[] = $middleware;
+        }
+
+        return $this;
+    }
+
+    /**
      * Return the application instance.
      *
      * @return Application
@@ -261,6 +302,26 @@ class Kernel implements \Illuminate\Contracts\Http\Kernel
         return $this->app;
     }
 
+    /**
+     * Get the application's route middleware groups.
+     *
+     * @return array
+     */
+    public function getMiddlewareGroups()
+    {
+        return $this->middlewareGroups;
+    }
+
+    /**
+     * Get the application's route middleware.
+     *
+     * @return array
+     */
+    public function getRouteMiddleware()
+    {
+        return $this->routeMiddleware;
+    }
+    
     /**
      * Report the exception to the exception handler.
      *


### PR DESCRIPTION
I tried installing a Laravel Library and it couldn't register itself because the `pushMiddleware` method was missing from the Kernel.  
I compared the Themosis Kernel to the one from Laravel and noticed a few other methods that were missing, so I added those as well.