### PR TITLE
Added `php console make:request` command

### DIFF
--- a/src/Core/Console/RequestMakeCommand.php
+++ b/src/Core/Console/RequestMakeCommand.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Themosis\Core\Console;
+
+use Illuminate\Console\GeneratorCommand;
+
+class RequestMakeCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'make:request';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new form request class';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Request';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return __DIR__ . '/stubs/request.stub';
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace . '\Http\Requests';
+    }
+}

--- a/src/Core/Console/stubs/request.stub
+++ b/src/Core/Console/stubs/request.stub
@@ -1,0 +1,30 @@
+<?php
+
+namespace DummyNamespace;
+
+use Themosis\Core\Http\FormRequest;
+
+class DummyClass extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/src/Core/Providers/ConsoleServiceProvider.php
+++ b/src/Core/Providers/ConsoleServiceProvider.php
@@ -38,6 +38,7 @@ use Themosis\Core\Console\UpCommand;
 use Themosis\Core\Console\VendorPublishCommand;
 use Themosis\Core\Console\ViewClearCommand;
 use Themosis\Core\Console\WidgetMakeCommand;
+use Themosis\Core\Console\RequestMakeCommand;
 
 class ConsoleServiceProvider extends ServiceProvider
 {
@@ -96,7 +97,8 @@ class ConsoleServiceProvider extends ServiceProvider
         'ThemeInstall' => 'command.theme.install',
         'VendorPublish' => 'command.vendor.publish',
         'Serve' => 'command.serve',
-        'WidgetMake' => 'command.widget.make'
+        'WidgetMake' => 'command.widget.make',
+        'RequestMake' => 'command.request.make',
     ];
 
     /**
@@ -539,6 +541,18 @@ class ConsoleServiceProvider extends ServiceProvider
     {
         $this->app->singleton($abstract, function ($app) {
             return new WidgetMakeCommand($app['files']);
+        });
+    }
+
+    /**
+     * Register the make:request command.
+     *
+     * @param string $abstract
+     */
+    protected function registerRequestMakeCommand($abstract)
+    {
+        $this->app->singleton($abstract, function ($app) {
+            return new RequestMakeCommand($app['files']);
         });
     }
 

--- a/src/Core/Providers/ConsoleServiceProvider.php
+++ b/src/Core/Providers/ConsoleServiceProvider.php
@@ -93,12 +93,12 @@ class ConsoleServiceProvider extends ServiceProvider
         'PasswordResetTable' => 'command.password.reset.table',
         'PluginInstall' => 'command.plugin.install',
         'ProviderMake' => 'command.provider.make',
+        'RequestMake' => 'command.request.make',
         'SessionTable' => 'command.session.table',
         'ThemeInstall' => 'command.theme.install',
         'VendorPublish' => 'command.vendor.publish',
         'Serve' => 'command.serve',
         'WidgetMake' => 'command.widget.make',
-        'RequestMake' => 'command.request.make',
     ];
 
     /**
@@ -409,6 +409,18 @@ class ConsoleServiceProvider extends ServiceProvider
     }
 
     /**
+     * Register the make:request command.
+     *
+     * @param string $abstract
+     */
+    protected function registerRequestMakeCommand($abstract)
+    {
+        $this->app->singleton($abstract, function ($app) {
+            return new RequestMakeCommand($app['files']);
+        });
+    }
+
+    /**
      * Register the route:cache command.
      *
      * @param string $abstract
@@ -541,18 +553,6 @@ class ConsoleServiceProvider extends ServiceProvider
     {
         $this->app->singleton($abstract, function ($app) {
             return new WidgetMakeCommand($app['files']);
-        });
-    }
-
-    /**
-     * Register the make:request command.
-     *
-     * @param string $abstract
-     */
-    protected function registerRequestMakeCommand($abstract)
-    {
-        $this->app->singleton($abstract, function ($app) {
-            return new RequestMakeCommand($app['files']);
         });
     }
 


### PR DESCRIPTION
Hi @jlambe !

Today played around with 2.0, with all new features, a great job is done!

Also wanted to try [Laravel Request Forms](https://laravel.com/docs/5.8/validation#form-request-validation) in action, noticed that you have `FormRequest` already in the Core,  but 'make:request' command was missed, so I've added, hope you don't mind :) 