### PR TITLE
Added `php console make:resource` command

### DIFF
--- a/src/Core/Console/ResourceMakeCommand.php
+++ b/src/Core/Console/ResourceMakeCommand.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Themosis\Core\Console;
+
+use Illuminate\Support\Str;
+use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Input\InputOption;
+
+class ResourceMakeCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'make:resource';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new resource';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Resource';
+
+    /**
+     * Execute the console command.
+     *
+     * @return bool|void|null
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     */
+    public function handle()
+    {
+        if ($this->collection()) {
+            $this->type = 'Resource collection';
+        }
+
+        parent::handle();
+    }
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return $this->collection()
+            ? __DIR__.'/stubs/resource-collection.stub'
+            : __DIR__.'/stubs/resource.stub';
+    }
+
+    /**
+     * Determine if the command is generating a resource collection.
+     *
+     * @return bool
+     */
+    protected function collection()
+    {
+        return $this->option('collection') ||
+            Str::endsWith($this->argument('name'), 'Collection');
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace.'\Http\Resources';
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['collection', 'c', InputOption::VALUE_NONE, 'Create a resource collection'],
+        ];
+    }
+}

--- a/src/Core/Console/stubs/resource-collection.stub
+++ b/src/Core/Console/stubs/resource-collection.stub
@@ -1,0 +1,19 @@
+<?php
+
+namespace DummyNamespace;
+
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class DummyClass extends ResourceCollection
+{
+    /**
+     * Transform the resource collection into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return parent::toArray($request);
+    }
+}

--- a/src/Core/Console/stubs/resource.stub
+++ b/src/Core/Console/stubs/resource.stub
@@ -1,0 +1,19 @@
+<?php
+
+namespace DummyNamespace;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class DummyClass extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return parent::toArray($request);
+    }
+}

--- a/src/Core/Providers/ConsoleServiceProvider.php
+++ b/src/Core/Providers/ConsoleServiceProvider.php
@@ -39,6 +39,7 @@ use Themosis\Core\Console\VendorPublishCommand;
 use Themosis\Core\Console\ViewClearCommand;
 use Themosis\Core\Console\WidgetMakeCommand;
 use Themosis\Core\Console\RequestMakeCommand;
+use Themosis\Core\Console\ResourceMakeCommand;
 
 class ConsoleServiceProvider extends ServiceProvider
 {
@@ -94,6 +95,7 @@ class ConsoleServiceProvider extends ServiceProvider
         'PluginInstall' => 'command.plugin.install',
         'ProviderMake' => 'command.provider.make',
         'RequestMake' => 'command.request.make',
+        'ResourceMake' => 'command.resource.make',
         'SessionTable' => 'command.session.table',
         'ThemeInstall' => 'command.theme.install',
         'VendorPublish' => 'command.vendor.publish',
@@ -417,6 +419,18 @@ class ConsoleServiceProvider extends ServiceProvider
     {
         $this->app->singleton($abstract, function ($app) {
             return new RequestMakeCommand($app['files']);
+        });
+    }
+
+    /**
+     * Register the make:resource command.
+     *
+     * @param string $abstract
+     */
+    protected function registerResourceMakeCommand($abstract)
+    {
+        $this->app->singleton($abstract, function ($app) {
+            return new ResourceMakeCommand($app['files']);
         });
     }
 


### PR DESCRIPTION
Hi @jlambe!

I've added a new Console command `make:resource` which is going to help to work with [API Resources](https://laravel.com/docs/5.8/eloquent-resources#generating-resources).

The command is the same as Laravel has. 
Thanks.