### PR TITLE
use the wordpress default function to retrieve post meta

### DIFF
--- a/src/View/Extensions/WordPress.php
+++ b/src/View/Extensions/WordPress.php
@@ -65,8 +65,8 @@ class WordPress extends \Twig_Extension implements \Twig_Extension_GlobalsInterf
 
                 return call_user_func_array(trim($name), $args);
             }),
-            new \Twig_Function('meta', function ($key, $id = null, $context = 'post', $single = true) {
-                return meta($key, $id, $context, $single);
+            new \Twig_Function('meta', function ($key, $id = null, $single = false) {
+                return get_post_meta($key, $id, $single);
             }),
 
             /**


### PR DESCRIPTION
The Twig section of the documentation is mentioning a `meta()` filter. But this method was returning a 

```
Call to undefined function Themosis\View\Extensions\meta()
```

As the new way of displaying content from Metabox (cf documentation 2.0) is by using the wordpress native `get_post_meta()`, this PR should follow this practice for the Twig filter