### PR TITLE
Added an ability to pass additional vars into `User::can`

### DIFF
--- a/src/User/User.php
+++ b/src/User/User.php
@@ -41,7 +41,7 @@ class User extends \WP_User
      */
     public function can($cap)
     {
-        return $this->has_cap($cap);
+        return $this->has_cap(...func_get_args());
     }
 
     /**


### PR DESCRIPTION
Hi @jlambe  

I've noticed that the [`Themosis\User\User:class`](https://github.com/themosis/framework/blob/17d07c97858b0811d9f22e8b72593953d7f365fd/src/User/User.php#L42) doesn't have an ability to pass extra vars as it does the `current_user_can()`

I've added that ability.

Was before: `User::can('edit_post')`

Right now: `User::can('edit_post', $post_id)`

How do you think, does it make sense?
