### PR TITLE
Twig helper

### DIFF
--- a/src/Core/helpers.php
+++ b/src/Core/helpers.php
@@ -416,19 +416,18 @@ if (! function_exists('meta')) {
     /**
      * Retrieve metadata for the specified object.
      *
-     * @param string    $meta_type 
      * @param int       $object_id
      * @param string    $meta_key
      * @param bool      $single
+     * @param string    $meta_type 
      *
      * @return mixed
      */
-    function meta($meta_type, $object_id, $meta_key = '', $single = false)
+    function meta($object_id, $meta_key = '', $single = false, $meta_type = 'post')
     {
         return get_metadata($meta_type, $object_id, $meta_key, $single);
     }
 }
-
 if (! function_exists('method_field')) {
     /**
      * Generate a form field to spoof the HTTP verb usef by forms.

--- a/src/Core/helpers.php
+++ b/src/Core/helpers.php
@@ -412,6 +412,23 @@ if (! function_exists('logs')) {
     }
 }
 
+if (! function_exists('meta')) {
+    /**
+     * Retrieve metadata for the specified object.
+     *
+     * @param string    $meta_type 
+     * @param int       $object_id
+     * @param string    $meta_key
+     * @param bool      $single
+     *
+     * @return mixed
+     */
+    function meta($meta_type, $object_id, $meta_key = '', $single = false)
+    {
+        return get_metadata($meta_type, $object_id, $meta_key, $single);
+    }
+}
+
 if (! function_exists('method_field')) {
     /**
      * Generate a form field to spoof the HTTP verb usef by forms.

--- a/src/View/Extensions/WordPress.php
+++ b/src/View/Extensions/WordPress.php
@@ -65,8 +65,8 @@ class WordPress extends \Twig_Extension implements \Twig_Extension_GlobalsInterf
 
                 return call_user_func_array(trim($name), $args);
             }),
-            new \Twig_Function('meta', function ($key, $id = null, $context = 'post', $single = true) {
-                return meta($key, $id, $context, $single);
+            new \Twig_Function('meta', function ($object_id, $meta_key = '', $single = false, $meta_type = 'post') {
+                return meta($object_id, $meta_key, $single, $meta_type);
             }),
 
             /**

--- a/src/View/Extensions/WordPress.php
+++ b/src/View/Extensions/WordPress.php
@@ -65,8 +65,8 @@ class WordPress extends \Twig_Extension implements \Twig_Extension_GlobalsInterf
 
                 return call_user_func_array(trim($name), $args);
             }),
-            new \Twig_Function('meta', function ($key, $id = null, $single = false) {
-                return get_post_meta($key, $id, $single);
+            new \Twig_Function('meta', function ($key, $id = null, $context = 'post', $single = true) {
+                return meta($key, $id, $context, $single);
             }),
 
             /**

--- a/src/View/Extensions/WordPress.php
+++ b/src/View/Extensions/WordPress.php
@@ -65,8 +65,8 @@ class WordPress extends \Twig_Extension implements \Twig_Extension_GlobalsInterf
 
                 return call_user_func_array(trim($name), $args);
             }),
-            new \Twig_Function('meta', function ($key, $id = null, $context = 'post', $single = true) {
-                return meta($key, $id, $context, $single);
+            new \Twig_Function('meta', function ($key, $id = null, $single = false) {
+                return get_post_meta($key, $id, $single);
             }),
 
             /**


### PR DESCRIPTION
Creates a global `meta()` function helper to compensate the missing `meta` from the core functions.

Return the `get_metadata()` function.