### PR TITLE
Add missing domain path when creating theme

### DIFF
--- a/src/Core/Console/ThemeInstallCommand.php
+++ b/src/Core/Console/ThemeInstallCommand.php
@@ -113,6 +113,7 @@ License: GPL-2.0-or-later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Tags: easy, organized, expressive.
 Text Domain: $textdomain
+Domain Path: languages
 */
 STYLES;
 


### PR DESCRIPTION
Translations weren't working for us because the Domain Path gets removed when you use the `theme:install` command.  
Domain path is already located in the default theme [style.css](https://github.com/themosis/theme/blob/184bb0bf791b418f1b1be404419baff81f69b24c/style.css#L12), but gets removed because the command doesn't contain it.