### PR TITLE
Added compatibility for sub pages in settings menu

### DIFF
--- a/src/Page/Page.php
+++ b/src/Page/Page.php
@@ -382,7 +382,7 @@ class Page implements PageInterface
         if (false !== $pos = strpos($this->getParent(), 'post_type=')) {
             // Parent hook is equivalent to the post type slug value.
             return substr($this->getParent(), $pos + 10);
-        } else ('edit.php' === trim($this->getParent(), '\/?&')) {
+        } else {
             switch (trim($this->getParent(), '\/?&')) {
                 case 'index.php':
                     return 'dashboard';

--- a/src/Page/Page.php
+++ b/src/Page/Page.php
@@ -385,6 +385,8 @@ class Page implements PageInterface
         } elseif ('edit.php' === trim($this->getParent(), '\/?&')) {
             // Parent is the default post post type.
             return 'posts';
+        } elseif ('options-general.php' === trim($this->getParent(), '\/?&')) {
+            return 'settings';
         }
 
         // The current page is attached to another one.

--- a/src/Page/Page.php
+++ b/src/Page/Page.php
@@ -382,11 +382,27 @@ class Page implements PageInterface
         if (false !== $pos = strpos($this->getParent(), 'post_type=')) {
             // Parent hook is equivalent to the post type slug value.
             return substr($this->getParent(), $pos + 10);
-        } elseif ('edit.php' === trim($this->getParent(), '\/?&')) {
-            // Parent is the default post post type.
-            return 'posts';
-        } elseif ('options-general.php' === trim($this->getParent(), '\/?&')) {
-            return 'settings';
+        } else ('edit.php' === trim($this->getParent(), '\/?&')) {
+            switch (trim($this->getParent(), '\/?&')) {
+                case 'index.php':
+                    return 'dashboard';
+                case 'edit.php':
+                    return 'posts';
+                case 'upload.php':
+                    return 'media';
+                case 'edit-comments.php':
+                    return 'comments';
+                case 'themes.php':
+                    return 'appearance';
+                case 'plugins.php':
+                    return 'plugins';
+                case 'users.php':
+                    return 'users';
+                case 'tools.php':
+                    return 'tools';
+                case 'options-general.php':
+                    return 'settings';
+            }
         }
 
         // The current page is attached to another one.


### PR DESCRIPTION
You can add a subpage to the `option-general.php` page but when you want to use the subroute system with `?action` it fails.

Example code:
```
$page->make('page', 'Page')
    ->setParent('options-general.php')
    ->setTitle('Page')
    ->route('/', "Controller@home", 'get', 'Page Home')
    ->set();
```

The above sub route (`/`) will not be triggered but when you add the proposed code it will.

Ps. I'm not entirely sure to what branch it needs to go to so I selected the master branch.