### PR TITLE
Add Service provider auto-registration after requiring packages

### DIFF
--- a/src/Core/ComposerScripts.php
+++ b/src/Core/ComposerScripts.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Themosis\Core;
+
+use Composer\Script\Event;
+
+class ComposerScripts
+{
+    /**
+     * Handle the post-install Composer event.
+     *
+     * @param  \Composer\Script\Event  $event
+     * @return void
+     */
+    public static function postInstall(Event $event)
+    {
+        require_once $event->getComposer()->getConfig()->get('vendor-dir').'/autoload.php';
+
+        static::clearCompiled();
+    }
+
+    /**
+     * Handle the post-update Composer event.
+     *
+     * @param  \Composer\Script\Event  $event
+     * @return void
+     */
+    public static function postUpdate(Event $event)
+    {
+        require_once $event->getComposer()->getConfig()->get('vendor-dir').'/autoload.php';
+
+        static::clearCompiled();
+    }
+
+    /**
+     * Handle the post-autoload-dump Composer event.
+     *
+     * @param  \Composer\Script\Event  $event
+     * @return void
+     */
+    public static function postAutoloadDump(Event $event)
+    {
+        require_once $event->getComposer()->getConfig()->get('vendor-dir').'/autoload.php';
+
+        static::clearCompiled();
+    }
+
+    /**
+     * Clear the cached Themosis bootstrapping files.
+     *
+     * @return void
+     */
+    protected static function clearCompiled()
+    {
+        /*----------------------------------------------------*/
+        // Directory separator
+        /*----------------------------------------------------*/
+        defined('DS') ? DS : define('DS', DIRECTORY_SEPARATOR);
+
+        /*----------------------------------------------------*/
+        // Application paths
+        /*----------------------------------------------------*/
+        defined('THEMOSIS_PUBLIC_DIR') ?  THEMOSIS_PUBLIC_DIR : define('THEMOSIS_PUBLIC_DIR', 'htdocs');
+        defined('THEMOSIS_ROOT') ? THEMOSIS_ROOT : define('THEMOSIS_ROOT', realpath(getcwd()));
+        defined('CONTENT_DIR') ? CONTENT_DIR : define('CONTENT_DIR', 'content');
+        defined('WP_CONTENT_DIR') ? WP_CONTENT_DIR : define('WP_CONTENT_DIR', realpath(THEMOSIS_ROOT.DS.THEMOSIS_PUBLIC_DIR.DS.CONTENT_DIR));
+
+        $app = new Application(getcwd());
+
+        if (file_exists($servicesPath = $app->getCachedServicesPath())) {
+            @unlink($servicesPath);
+        }
+
+        if (file_exists($packagesPath = $app->getCachedPackagesPath())) {
+            @unlink($packagesPath);
+        }
+    }
+}

--- a/src/Core/Console/PackageDiscoverCommand.php
+++ b/src/Core/Console/PackageDiscoverCommand.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Themosis\Core\Console;
+
+use Illuminate\Console\Command;
+use Themosis\Core\PackageManifest;
+
+class PackageDiscoverCommand extends Command
+{
+    /**
+     * The console command signature.
+     *
+     * @var string
+     */
+    protected $signature = 'package:discover';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Rebuild the cached package manifest';
+
+    /**
+     * Execute the console command.
+     *
+     * @param  \Themosis\Core\PackageManifest  $manifest
+     * @return void
+     */
+    public function handle(PackageManifest $manifest)
+    {
+        $manifest->build();
+
+        foreach (array_keys($manifest->manifest) as $package) {
+            $this->line("Discovered Package: <info>{$package}</info>");
+        }
+
+        $this->info('Package manifest generated successfully.');
+    }
+}

--- a/src/Core/PackageManifest.php
+++ b/src/Core/PackageManifest.php
@@ -104,7 +104,7 @@ class PackageManifest
     /**
      * Generate the packages.php manifest file.
      */
-    protected function build()
+    public function build()
     {
         $packages = [];
 

--- a/src/Core/Providers/ConsoleServiceProvider.php
+++ b/src/Core/Providers/ConsoleServiceProvider.php
@@ -26,6 +26,7 @@ use Themosis\Core\Console\HookMakeCommand;
 use Themosis\Core\Console\KeyGenerateCommand;
 use Themosis\Core\Console\MailMakeCommand;
 use Themosis\Core\Console\ModelMakeCommand;
+use Themosis\Core\Console\PackageDiscoverCommand;
 use Themosis\Core\Console\PasswordResetTableCommand;
 use Themosis\Core\Console\PluginInstallCommand;
 use Themosis\Core\Console\ProviderMakeCommand;
@@ -65,6 +66,7 @@ class ConsoleServiceProvider extends ServiceProvider
         'MigrateReset' => 'command.migrate.reset',
         'MigrateRollback' => 'command.migrate.rollback',
         'MigrateStatus' => 'command.migrate.status',
+        'PackageDiscover' => 'command.package.discover',
         'RouteCache' => 'command.route.cache',
         'RouteClear' => 'command.route.clear',
         'RouteList' => 'command.route.list',
@@ -371,6 +373,18 @@ class ConsoleServiceProvider extends ServiceProvider
     {
         $this->app->singleton($abstract, function ($app) {
             return new ModelMakeCommand($app['files']);
+        });
+    }
+
+    /**
+     * Register the package:discover command.
+     *
+     * @param string $abstract
+     */
+    protected function registerPackageDiscoverCommand($abstract)
+    {
+        $this->app->singleton($abstract, function ($app) {
+            return new PackageDiscoverCommand($app['files'], $app['composer']);
         });
     }
 

--- a/src/Core/Providers/ConsoleServiceProvider.php
+++ b/src/Core/Providers/ConsoleServiceProvider.php
@@ -384,7 +384,7 @@ class ConsoleServiceProvider extends ServiceProvider
     protected function registerPackageDiscoverCommand($abstract)
     {
         $this->app->singleton($abstract, function ($app) {
-            return new PackageDiscoverCommand($app['files'], $app['composer']);
+            return new PackageDiscoverCommand();
         });
     }
 


### PR DESCRIPTION
### Why

When requiring a Laravel's package, we need to manually set package's services providers and aliases on our `config/app.php` file.
This PR add the ability to auto discover packages and rebuild `bootstrap/cache` files after using `composer require packageName` command.

### How

*  Add package:discover command to discover packages (with PackageManifest)
*  Add ComposerScripts class to clear packages and services discovered
after composer's script events

### More details

Method `ComposerScripts::postAutoloadDump` is used after composer `post-autoload-dump` event, and call `Themosis\Core\Application.php` class to find packages and services cached files. In this context, constants on `wp-config.php` files are missing, so i redefined them juste before instanciating Themosis\Core\Application.php`.

I changed the visibility of the `build()` function on `PackageManifest.php` class. It was set to `protected`, i changed it to `public`, because this function is used on `ComposerScripts::postAutoloadDump`.
The same visibility is set on Laravel's repo : https://github.com/laravel/framework/blob/5.8/src/Illuminate/Foundation/PackageManifest.php

resolve #686 