### PR TITLE
get posttype method + test

### DIFF
--- a/src/PostType/Factory.php
+++ b/src/PostType/Factory.php
@@ -37,41 +37,45 @@ class Factory
      * @param string $plural
      * @param string $singular
      *
+     * @return PostTypeInterface
      * @throws PostTypeException
      *
-     * @return PostTypeInterface
      */
     public function make(string $slug, string $plural, string $singular): PostTypeInterface
     {
         $postType = (new PostType($slug, $this->action, $this->filter))
-            ->setLabels([
-                'name' => $plural,
-                'singular_name' => $singular,
-                'add_new_item' => sprintf('Add New %s', $singular),
-                'edit_item' => sprintf('Edit %s', $singular),
-                'new_item' => sprintf('New %s', $singular),
-                'view_item' => sprintf('View %s', $singular),
-                'view_items' => sprintf('View %s', $plural),
-                'search_items' => sprintf('Search %s', $plural),
-                'not_found' => sprintf('No %s found', $plural),
-                'not_found_in_trash' => sprintf('No %s found in Trash', $plural),
-                'parent_item_colon' => sprintf('Parent %s:', $singular),
-                'all_items' => sprintf('All %s', $plural),
-                'archives' => sprintf('%s Archives', $singular),
-                'attributes' => sprintf('%s Attributes', $singular),
-                'insert_into_item' => sprintf('Insert into %s', strtolower($singular)),
-                'uploaded_to_this_item' => sprintf('Uploaded to this %s', strtolower($singular)),
-                'filter_items_list' => sprintf('Filter %s list', strtolower($plural)),
-                'items_list_navigation' => sprintf('%s list navigation', $plural),
-                'items_list' => sprintf('%s list', $plural)
-            ])
-            ->setArguments([
-                'public' => true,
-                'show_in_rest' => true,
-                'menu_position' => 20,
-                'supports' => ['title'],
-                'has_archive' => true
-            ]);
+            ->setLabels(
+                [
+                    'name'                  => $plural,
+                    'singular_name'         => $singular,
+                    'add_new_item'          => sprintf('Add New %s', $singular),
+                    'edit_item'             => sprintf('Edit %s', $singular),
+                    'new_item'              => sprintf('New %s', $singular),
+                    'view_item'             => sprintf('View %s', $singular),
+                    'view_items'            => sprintf('View %s', $plural),
+                    'search_items'          => sprintf('Search %s', $plural),
+                    'not_found'             => sprintf('No %s found', $plural),
+                    'not_found_in_trash'    => sprintf('No %s found in Trash', $plural),
+                    'parent_item_colon'     => sprintf('Parent %s:', $singular),
+                    'all_items'             => sprintf('All %s', $plural),
+                    'archives'              => sprintf('%s Archives', $singular),
+                    'attributes'            => sprintf('%s Attributes', $singular),
+                    'insert_into_item'      => sprintf('Insert into %s', strtolower($singular)),
+                    'uploaded_to_this_item' => sprintf('Uploaded to this %s', strtolower($singular)),
+                    'filter_items_list'     => sprintf('Filter %s list', strtolower($plural)),
+                    'items_list_navigation' => sprintf('%s list navigation', $plural),
+                    'items_list'            => sprintf('%s list', $plural),
+                ]
+            )
+            ->setArguments(
+                [
+                    'public'        => true,
+                    'show_in_rest'  => true,
+                    'menu_position' => 20,
+                    'supports'      => ['title'],
+                    'has_archive'   => true,
+                ]
+            );
 
         $abstract = sprintf('themosis.posttype.%s', $slug);
 
@@ -95,5 +99,21 @@ class Factory
     {
         return $this->container->has("themosis.posttype.{$slug}")
             || (function_exists('post_type_exists') && post_type_exists($slug));
+    }
+
+    /**
+     * @param string $slug
+     *
+     * @return PostTypeInterface|null
+     */
+    public function get(string $slug): ?PostTypeInterface
+    {
+        $id = "themosis.posttype.{$slug}";
+
+        if (!$this->container->has($id)) {
+            return null;
+        }
+
+        return $this->container->get($id);
     }
 }

--- a/tests/PostType/PostTypeTest.php
+++ b/tests/PostType/PostTypeTest.php
@@ -89,4 +89,15 @@ class PostTypeTest extends TestCase
 
         $this->assertFalse($factory->exists('non-existent-post-type'));
     }
+
+    public function testGetPostType()
+    {
+        $factory = $this->getFactory();
+
+        $books = $factory->make('book', 'Books', 'Book');
+        $post_type = $factory->get('book');
+        $this->assertSame($books, $post_type);
+
+        $this->assertNull($factory->get('non-existent-post-type'));
+    }
 }


### PR DESCRIPTION
Returns null when no post type is registered with the given id.

Examples:
```php
PostType::get('book');
```
```php
$post_type = PostType::get('book');
if($post_type)
{
    $post_type = $post_type->getInstance();
}
```