### PR TITLE
Setup to use Redis as a Cache driver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,7 @@
     "illuminate/notifications": "^5.8",
     "illuminate/pagination": "^5.8",
     "illuminate/queue": "^5.8",
+    "illuminate/redis": "^5.8",
     "illuminate/routing": "^5.8",
     "illuminate/session": "^5.8",
     "illuminate/support": "^5.8",

--- a/src/Core/Application.php
+++ b/src/Core/Application.php
@@ -286,6 +286,10 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
             'redirect' => [
                 \Illuminate\Routing\Redirector::class
             ],
+            'redis' => [
+                \Illuminate\Redis\RedisManager::class,
+                \Illuminate\Contracts\Redis\Factory::class
+            ],
             'request' => [
                 \Illuminate\Http\Request::class,
                 \Symfony\Component\HttpFoundation\Request::class


### PR DESCRIPTION
### Why

Actually, on 2.0.3, we can't use `Redis` as a Cache driver. `Redis` class, provider, alias... are missing.

### How

On `composer.json`, require the `illuminate/redis` package, and add `Redis` manager and factory to the `Themosis\Core\Application.php` file, on `registerCoreContainerAliases` method.

resolve #698 