### PR TITLE
Access Wordpress, theme and plugins functions on CLI

### DIFF
--- a/src/Core/Console/ConsoleMakeCommand.php
+++ b/src/Core/Console/ConsoleMakeCommand.php
@@ -9,13 +9,6 @@ use Symfony\Component\Console\Input\InputOption;
 class ConsoleMakeCommand extends GeneratorCommand
 {
     /**
-     * The name and signature of the console command.
-     *
-     * @var string
-     */
-    //protected $signature = 'make:command {name : The name of the command.} {--command=command:name : The terminal command that should be assigned.} {--load-wordpress : Load Wordpress functions into the command.}';
-
-    /**
      * The console command name.
      *
      * @var string
@@ -43,8 +36,6 @@ class ConsoleMakeCommand extends GeneratorCommand
      */
     protected function getStub()
     {
-        dump($this->getOptions());
-        dump($this->getArguments());
         if ($this->option('load-wordpress')) {
             return __DIR__.'/stubs/console-wordpress.stub';
         } else {

--- a/src/Core/Console/ConsoleMakeCommand.php
+++ b/src/Core/Console/ConsoleMakeCommand.php
@@ -9,6 +9,13 @@ use Symfony\Component\Console\Input\InputOption;
 class ConsoleMakeCommand extends GeneratorCommand
 {
     /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    //protected $signature = 'make:command {name : The name of the command.} {--command=command:name : The terminal command that should be assigned.} {--load-wordpress : Load Wordpress functions into the command.}';
+
+    /**
      * The console command name.
      *
      * @var string
@@ -36,7 +43,13 @@ class ConsoleMakeCommand extends GeneratorCommand
      */
     protected function getStub()
     {
-        return __DIR__.'/stubs/console.stub';
+        dump($this->getOptions());
+        dump($this->getArguments());
+        if ($this->option('load-wordpress')) {
+            return __DIR__.'/stubs/console-wordpress.stub';
+        } else {
+            return __DIR__.'/stubs/console.stub';
+        }
     }
 
     /**
@@ -92,6 +105,12 @@ class ConsoleMakeCommand extends GeneratorCommand
                 InputOption::VALUE_OPTIONAL,
                 'The terminal command that should be assigned.',
                 'command:name'
+            ],
+            [
+                'load-wordpress',
+                null,
+                InputOption::VALUE_NONE,
+                'Load Wordpress functions into the command.'
             ]
         ];
     }

--- a/src/Core/Console/stubs/console-wordpress.stub
+++ b/src/Core/Console/stubs/console-wordpress.stub
@@ -3,9 +3,12 @@
 namespace DummyNamespace;
 
 use Illuminate\Console\Command;
+use Themosis\Core\LoadWordpress;
 
 class DummyClass extends Command
 {
+    use LoadWordpress;
+
     /**
      * The console command name.
      *
@@ -37,6 +40,7 @@ class DummyClass extends Command
      */
     public function handle()
     {
-        //
+        // load Wordpress into this command
+        $this->loadWordpress();
     }
 }

--- a/src/Core/Console/stubs/console.stub
+++ b/src/Core/Console/stubs/console.stub
@@ -24,13 +24,6 @@ class DummyClass extends Command
     protected $description = 'Command description';
 
     /**
-     * Choose to load Worpdress's wp-load.php file if true
-     *
-     * @var bool
-     */
-    protected $loadWp = false;
-
-    /**
      * Create a new command instance.
      *
      * @return void
@@ -38,8 +31,6 @@ class DummyClass extends Command
     public function __construct()
     {
         parent::__construct();
-
-        $this->loadWordpress();
     }
 
     /**
@@ -49,6 +40,7 @@ class DummyClass extends Command
      */
     public function handle()
     {
-        //
+        // load Wordpress into this command
+        $this->loadWordpress();
     }
 }

--- a/src/Core/Console/stubs/console.stub
+++ b/src/Core/Console/stubs/console.stub
@@ -3,9 +3,12 @@
 namespace DummyNamespace;
 
 use Illuminate\Console\Command;
+use Themosis\Core\LoadWordpress;
 
 class DummyClass extends Command
 {
+    use LoadWordpress;
+
     /**
      * The console command name.
      *
@@ -21,6 +24,13 @@ class DummyClass extends Command
     protected $description = 'Command description';
 
     /**
+     * Choose to load Worpdress's wp-load.php file if true
+     *
+     * @var bool
+     */
+    protected $loadWp = false;
+
+    /**
      * Create a new command instance.
      *
      * @return void
@@ -28,6 +38,8 @@ class DummyClass extends Command
     public function __construct()
     {
         parent::__construct();
+
+        $this->loadWordpress();
     }
 
     /**

--- a/src/Core/LoadWordpress.php
+++ b/src/Core/LoadWordpress.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Themosis\Core;
+
+trait LoadWordpress
+{
+    /**
+     * Load Wordpress's wp-load.php file
+     */
+    protected function loadWordpress(): void
+    {
+        if ($this->loadWp) {
+            require web_path('cms/wp-load.php');
+        }
+    }
+}

--- a/src/Core/LoadWordpress.php
+++ b/src/Core/LoadWordpress.php
@@ -10,7 +10,7 @@ trait LoadWordpress
     protected function loadWordpress(): void
     {
         if ($this->loadWp) {
-            require web_path('cms/wp-load.php');
+            require_once web_path('cms/wp-load.php');
         }
     }
 }

--- a/src/Core/LoadWordpress.php
+++ b/src/Core/LoadWordpress.php
@@ -9,8 +9,6 @@ trait LoadWordpress
      */
     protected function loadWordpress(): void
     {
-        if ($this->loadWp) {
-            require_once web_path('cms/wp-load.php');
-        }
+        require_once web_path('cms/wp-load.php');
     }
 }


### PR DESCRIPTION
### Why

When we are making a custom command (using `php console make:command`), we are unable to use Wordpress's functions as Wordpress is not loaded.
This PR's goal is to require the `wp-load.php` on a command when needed.

### How

- Add a new Trait on `Themosis\Core` namespace. This trait will have a method that will require the `wp-load.php` file.

- Make `console-wordpress.stub` that create the command, loading Wordpress with the `LoadWordpress` trait, this stub will be use while using the option `--load-wordpress` => `php console make:command myCommand --load-wordpress`

### More

**Why use a trait ?**
Instead of defining a method on every command to load Wordpress when needed, i used a trait, this way we will can use this trait on another places in the futur if needed.

**Does CLI works without Wordpress already installed ?**
If Wordpress is not installed, the `--load-wordpress` option should not be used.

### Example of a new command

`php console make:command TestWordpressGetMeta --load-wordpress`

``` php
<?php

namespace App\Console\Commands;

use Illuminate\Console\Command;
use Themosis\Core\LoadWordpress;

class TestWordpressGetMeta extends Command
{
    use LoadWordpress;

    /**
     * The console command name.
     *
     * @var string
     */
    protected $signature = 'command:name';

    /**
     * The console command description.
     *
     * @var string
     */
    protected $description = 'Command description';

    /**
     * Create a new command instance.
     *
     * @return void
     */
    public function __construct()
    {
        parent::__construct();
    }

    /**
     * Execute the console command.
     *
     * @return mixed
     */
    public function handle()
    {
        $this->loadWordpress();
    }
}
``` 

resolve #646 