### PR TITLE
Avoid exception when boolean data passed in DTO

### DIFF
--- a/src/Forms/Transformers/StringToBooleanTransformer.php
+++ b/src/Forms/Transformers/StringToBooleanTransformer.php
@@ -18,6 +18,10 @@ class StringToBooleanTransformer implements DataTransformerInterface
      */
     public function transform($data)
     {
+        if (is_bool($data) === true) {
+            return $data;
+        }
+
         if (is_null($data)) {
             return false;
         }


### PR DESCRIPTION
Not sure if there is a reason why what I'm proposing in this PR is not already done, but anyway the issue is that if I have an Eloquent Model where a property has a 'boolean' in the casts and I create a form with a DTO (as [documented here](https://framework.themosis.com/docs/2.0/form/#using-a-data-object)), the application throws the exception `DataTransformerException` with message "A string value is expected." (that one inside the method where you can see the change).

The reason is that the method might receive a "true" value in the `$data` variable and therefore the `!is_string` condition is verified, throwing an exception.

In my opinion, due to the nature of the transformer (`StringToBoolean`), if the method receives a `boolean` value, it shouldn't verify anything and should return the value as it is.

I hope it makes sense for you :)
Thanks.