### PR TITLE
fix `rootUrl()` double slashes; fix `route()` on admin pages

### DIFF
--- a/src/Core/helpers.php
+++ b/src/Core/helpers.php
@@ -668,8 +668,10 @@ if (! function_exists('rootUrl')) {
     function rootUrl(string $uri = ''): string
     {
         $request = app('request');
+        // ensure one slash on left, none on the right
+        $uri = ($uri) ? '/'.trim($uri, '/') : $uri;
 
-        return $request->getSchemeAndHttpHost().($uri ? '/'.$uri : $uri);
+        return $request->getSchemeAndHttpHost().$uri;
     }
 }
 
@@ -685,7 +687,8 @@ if (! function_exists('route')) {
      */
     function route($name, $parameters = [], $absolute = true)
     {
-        return app('url')->route($name, $parameters, $absolute);
+        $path = app('url')->route($name, $parameters, false);
+        return ($absolute) ? rootUrl($path) : $path;
     }
 }
 


### PR DESCRIPTION
fixes #705 

## rootUrl()
IMPORTANT: `rootUrl()` now never ends with a slash.

Fixed an issue where `rootUrl()` could return a double slash:
```php
rootUrl('/welcome') === 'http://localhost:8000//welcome' //true
```

## route()
`route()` made use of `app('url')->route()`, which on admin pages added `/cms/` to the base url.
```php
// true on admin pages
route('login') === 'http://localhost:8000/cms/login'
```
### Fix
Now this still uses the url helper to get the route's path, but instead it uses `rootUrl()` to apply the base URL.