### PR TITLE
Run tests on modern PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,19 @@ language: php
 matrix:
   fast_finish: true
   include:
-    - php: 7.1
     - php: 7.2
+    - php: 7.3
+    - php: 7.4snapshot
 
 cache:
   directories:
     - $HOME/.composer/cache
 
 install:
-  - travis_retry composer update --prefer-dist --no-interaction --no-suggest
+  - travis_retry composer install --prefer-dist --no-interaction --no-suggest
 
 before_script:
   - phpenv config-rm xdebug.ini
 
-script: vendor/bin/phpunit
+script:
+  - vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,8 @@ language: php
 matrix:
   fast_finish: true
   include:
-    - php: 7.2
     - php: 7.3
-    - php: 7.4snapshot
+    - php: 7.4
 
 cache:
   directories:


### PR DESCRIPTION
Laraval 6 - requiring PHP 7.2 - was introduced in https://github.com/themosis/framework/commit/d4bb0d47fcd3552a8ef4be17e1d1494acba3e4be
Fixes #755