### PR TITLE
Update PackageManifest for Composer 2 compatibility

### DIFF
--- a/src/Core/PackageManifest.php
+++ b/src/Core/PackageManifest.php
@@ -114,7 +114,7 @@ class PackageManifest
 
         $ignoreAll = in_array('*', $ignore = $this->packagesToIgnore());
 
-        $this->write(collect($packages)->mapWithKeys(function ($package) {
+        $this->write(collect($packages['packages'] ?? $packages)->mapWithKeys(function ($package) {
             return [$this->format($package['name']) => $package['extra']['laravel'] ?? []];
         })->each(function ($configuration) use (&$ignore) {
             $ignore = array_merge($ignore, $configuration['dont-discover'] ?? []);


### PR DESCRIPTION
Composer 2 is released and there are changed to the plugin API. Most notable the format for `installed.json` has changed and packages are now wrapped in a 'packages' top level key.  This breaks the package autodiscovery within the Themosis install process, this amend addresses this.