### PR TITLE
Updated the trans helpers to be inline with Laravel 8

### DIFF
--- a/src/Core/helpers.php
+++ b/src/Core/helpers.php
@@ -1084,7 +1084,7 @@ if (! function_exists('trans')) {
             return app('translator');
         }
 
-        return app('translator')->trans($key, $replace, $locale);
+        return app('translator')->get($key, $replace, $locale);
     }
 }
 
@@ -1101,7 +1101,7 @@ if (! function_exists('trans_choice')) {
      */
     function trans_choice($key, $number, array $replace = [], $locale = null)
     {
-        return app('translator')->transChoice($key, $number, $replace, $locale);
+        return app('translator')->choice($key, $number, $replace, $locale);
     }
 }
 


### PR DESCRIPTION
A  while ago Laravel changed their translation methods and so to make sure the helpers work again I updated them.

The trans helper function called Translator::trans and now it will call Translator::get.
The trans_choice helper function called Translator::transChoice and now it will call Translator::choice.

Ref: https://github.com/laravel/framework/commit/8557dc56b11c5e4dc746cb5558d6e694131f0dd8