### PR TITLE
Added hooks method to theme and plugin manager

### DIFF
--- a/src/Core/PluginManager.php
+++ b/src/Core/PluginManager.php
@@ -250,7 +250,7 @@ class PluginManager
     /**
      * Register plugin hookable class.
      *
-     * @param array $providers
+     * @param array $hooks
      *
      * @return $this
      */

--- a/src/Core/PluginManager.php
+++ b/src/Core/PluginManager.php
@@ -4,6 +4,7 @@ namespace Themosis\Core;
 
 use Composer\Autoload\ClassLoader;
 use Illuminate\Config\Repository;
+use Illuminate\Support\Collection;
 use Themosis\Asset\Finder;
 use Themosis\Core\Support\IncludesFiles;
 use Themosis\Core\Support\PluginHeaders;
@@ -243,6 +244,20 @@ class PluginManager
             $this->app->register(new $provider($this->app));
         }
 
+        return $this;
+    }
+
+    /**
+     * Register plugin hookable class.
+     *
+     * @param array $providers
+     *
+     * @return $this
+     */
+    public function hooks(array $hooks = [])
+    {
+        $hooks = Collection::make($hooks);
+        (new HooksRepository($this->app))->load($hooks->all());
         return $this;
     }
 

--- a/src/Core/ThemeManager.php
+++ b/src/Core/ThemeManager.php
@@ -4,6 +4,7 @@ namespace Themosis\Core;
 
 use Composer\Autoload\ClassLoader;
 use Illuminate\Config\Repository;
+use Illuminate\Support\Collection;
 use Themosis\Asset\Finder;
 use Themosis\Core\Support\IncludesFiles;
 use Themosis\Core\Support\WordPressFileHeaders;
@@ -225,6 +226,21 @@ class ThemeManager
 
         return $this;
     }
+
+    /**
+     * Register theme hookable class.
+     *
+     * @param array $providers
+     *
+     * @return $this
+     */
+    public function hooks(array $hooks = [])
+    {
+        $hooks = Collection::make($hooks);
+        (new HooksRepository($this->app))->load($hooks->all());
+        return $this;
+    }
+
 
     /**
      * Register theme views path.

--- a/src/Core/ThemeManager.php
+++ b/src/Core/ThemeManager.php
@@ -230,7 +230,7 @@ class ThemeManager
     /**
      * Register theme hookable class.
      *
-     * @param array $providers
+     * @param array $hooks
      *
      * @return $this
      */


### PR DESCRIPTION
Hello Julien,

By working on a generic theme that we want to re-use over the projects, I thought it would be interesting to be able to have Hookable classes within the theme and plugins.

The pull request contains the method for this. I also send a pull request for the theme and plugin repositories.

Good day !