### PR TITLE
Update cron-expression to ^3.0.2 in composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
   "require": {
     "php": "^7.3|^8.0",
     "composer/installers": "^1.9",
-    "dragonmantank/cron-expression": "^2.2",
+    "dragonmantank/cron-expression": "^3.0.2",
     "filp/whoops": "^2.1",
     "guzzlehttp/guzzle": "^7.2",
     "illuminate/auth": "^8.12",


### PR DESCRIPTION
Currently when running `php artisan schedule:run -vvv` you will get the following message:

```
In CronExpression.php line 154:
                                                
  [Error]                                       
  Call to a member function getField() on null  
                                                

Exception trace:
  at ~/vendor/dragonmantank/cron-expression/src/Cron/CronExpression.php:154
 Cron\CronExpression->setPart() at ~/vendor/dragonmantank/cron-expression/src/Cron/CronExpression.php:137
 Cron\CronExpression->setExpression() at ~/vendor/dragonmantank/cron-expression/src/Cron/CronExpression.php:116
 Cron\CronExpression->__construct() at ~/vendor/illuminate/console/Scheduling/Event.php:347
 Illuminate\Console\Scheduling\Event->expressionPasses() at ~/vendor/illuminate/console/Scheduling/Event.php:320
 Illuminate\Console\Scheduling\Event->isDue() at ~/vendor/illuminate/collections/HigherOrderCollectionProxy.php:60
 Illuminate\Support\HigherOrderCollectionProxy->Illuminate\Support\{closure}() at n/a:n/a
 array_filter() at ~/vendor/illuminate/collections/Arr.php:717
 Illuminate\Support\Arr::where() at ~/vendor/illuminate/collections/Collection.php:358
 Illuminate\Support\Collection->filter() at ~/vendor/illuminate/collections/HigherOrderCollectionProxy.php:61
 Illuminate\Support\HigherOrderCollectionProxy->__call() at ~/vendor/illuminate/console/Scheduling/Schedule.php:304
 Illuminate\Console\Scheduling\Schedule->dueEvents() at ~/vendor/illuminate/console/Scheduling/ScheduleRunCommand.php:92
 Illuminate\Console\Scheduling\ScheduleRunCommand->handle() at ~/vendor/illuminate/container/BoundMethod.php:36
 Illuminate\Container\BoundMethod::Illuminate\Container\{closure}() at ~/vendor/illuminate/container/Util.php:40
 Illuminate\Container\Util::unwrapIfClosure() at ~/vendor/illuminate/container/BoundMethod.php:93
 Illuminate\Container\BoundMethod::callBoundMethod() at ~/vendor/illuminate/container/BoundMethod.php:37
 Illuminate\Container\BoundMethod::call() at ~/vendor/illuminate/container/Container.php:653
 Illuminate\Container\Container->call() at ~/vendor/illuminate/console/Command.php:136
 Illuminate\Console\Command->execute() at ~/vendor/symfony/console/Command/Command.php:298
 Symfony\Component\Console\Command\Command->run() at ~/vendor/illuminate/console/Command.php:121
 Illuminate\Console\Command->run() at ~/vendor/symfony/console/Application.php:1005
 Symfony\Component\Console\Application->doRunCommand() at ~/vendor/symfony/console/Application.php:299
 Symfony\Component\Console\Application->doRun() at ~/vendor/symfony/console/Application.php:171
 Symfony\Component\Console\Application->run() at ~/vendor/illuminate/console/Application.php:94
 Illuminate\Console\Application->run() at ~/vendor/themosis/framework/src/Core/Console/Kernel.php:136
 Themosis\Core\Console\Kernel->handle() at ~/artisan:60
```

Which happens because since `cron-expression` version 3 you don't have to pass the FieldFactory anymore. And Laravel's `Illuminate/Events` already changed to the new spec which causes it to break on the older library.