### PR TITLE
Returning bool from comparison function is deprecated

### DIFF
--- a/src/View/FileViewFinder.php
+++ b/src/View/FileViewFinder.php
@@ -82,7 +82,7 @@ class FileViewFinder extends IlluminateFileViewFinder
         $orderedPaths = $this->orderedPaths;
 
         uasort($orderedPaths, function ($a, $b) {
-            return $a->getPriority() < $b->getPriority();
+            return $a->getPriority() <=> $b->getPriority();
         });
 
         foreach ($orderedPaths as $orderedPath) {


### PR DESCRIPTION
Hi Julien,

Just a small tweak on the comparison function to work with php 8+.

Tested on PHP 8.0.10.

`uasort(): Returning bool from comparison function is deprecated, return an integer less than, equal to, or greater than zero`