### PR TITLE
Fix custom post type published status issue

### DIFF
--- a/resources/js/index.ts
+++ b/resources/js/index.ts
@@ -69,10 +69,8 @@ window.addEventListener('load', () => {
     }
 
     if (form) {
-        form.addEventListener('submit', (event) => {
-            event.preventDefault();
+        form.addEventListener('submit', () => {
             window.dispatchEvent(new Event('isSavingPost'));
-            form.submit()
         });
     }
 });


### PR DESCRIPTION
This PR fixes an issue where the post status of a custom post type cannot be changed to Wordpress' built-in status of "published."  This occurs when a custom post type has been configured without "editor" support.

### Analysis
In order for the framework to provide a meta-box content auto-saving feature, it listens for the submission of a post's Add/Edit form and dispatches an "isSavingPost" event.  In doing this, the default form submission behaviour is prevented, the event is dispatched, and then the form is submitted via .submit(). The issue with this approach is that the .submit() function does not add names/values of submit buttons to the post data and this is something that Wordpress relies on internally.

### How to reproduce the problem
Create a custom post type using the framework's PostType facade, set supports to  an array excluding "editor," and try to publish a post.

```php
  PostType::make('slug', 'plural', 'singular')
          ->setArguments(['supports'  => ['title']])
          ->set();
```

### Solution
Dispatch "isSavingPost" event without changing default submission behaviour.