### PR TITLE
Use storage path if override has been set with useStoragePath()

### DIFF
--- a/src/Core/Application.php
+++ b/src/Core/Application.php
@@ -580,6 +580,10 @@ class Application extends Container implements
      */
     public function storagePath($path = '')
     {
+        if ($this->storagePath) {
+            return $this->storagePath . ($path ? DIRECTORY_SEPARATOR . $path : $path);
+        }
+
         if (defined('THEMOSIS_ROOT')) {
             return $this->rootPath('storage') . ($path ? DIRECTORY_SEPARATOR . $path : $path);
         }


### PR DESCRIPTION
Currently calling useStoragePath() on the application has no effect, this implements it.